### PR TITLE
fix: make bulk category operations atomic and correct README auth-header docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The app is split into two workspaces (`/client` and `/api`) managed as a bun mon
 ### Authentication Flow
 
 - **Client**: Firebase Auth handles sign-in (Google provider). The auth state is managed via `AuthContext` and a route loader redirects unauthenticated users to `/login`
-- **API**: Each function extracts the Firebase ID token from the `Authorization` header, verifies it via the Admin SDK, and uses the resulting `userId` to scope all database operations
+- **API**: Each function extracts the Firebase ID token from the `x-auth-token` header, verifies it via the Admin SDK, and uses the resulting `userId` to scope all database operations
 
 ### Data Model
 

--- a/api/database/firebaseDB.test.ts
+++ b/api/database/firebaseDB.test.ts
@@ -254,6 +254,27 @@ describe("firebaseDB", () => {
         "Swimming",
       ]);
     });
+
+    it("empties the category in one update when source and target are the same", async () => {
+      seedCategories({
+        catA: {
+          name: "Sports",
+          active: true,
+          description: "",
+          activityNames: ["Running", "Swimming"],
+        },
+      });
+
+      await firebaseDB.bulkReassignCategory(USER_ID, "catA", "catA");
+
+      // Colliding multi-path keys collapse to one; final state is empty
+      expect(updateCallCount).toBe(1);
+      expect(setCallCount).toBe(0);
+      const categories = getNestedValue(
+        `users/${USER_ID}/categories`
+      ) as CategoryMap;
+      expect(categories.catA.activityNames).toEqual([]);
+    });
   });
 
   describe("bulkAssignCategory", () => {
@@ -312,6 +333,33 @@ describe("firebaseDB", () => {
       expect(updateCallCount).toBe(1);
       expect(setCallCount).toBe(0);
 
+      const categories = getNestedValue(
+        `users/${USER_ID}/categories`
+      ) as CategoryMap;
+      expect(categories.catA.activityNames).toEqual(["Swimming"]);
+      expect(categories.catB.activityNames).toEqual(["Running"]);
+    });
+
+    it("adds to the target in a single update when the name is in no category", async () => {
+      seedCategories({
+        catA: {
+          name: "Sports",
+          active: true,
+          description: "",
+          activityNames: ["Swimming"],
+        },
+        catB: {
+          name: "Other",
+          active: true,
+          description: "",
+          activityNames: [],
+        },
+      });
+
+      await firebaseDB.bulkAssignCategory(USER_ID, "Running", "catB");
+
+      expect(updateCallCount).toBe(1);
+      expect(setCallCount).toBe(0);
       const categories = getNestedValue(
         `users/${USER_ID}/categories`
       ) as CategoryMap;

--- a/api/database/firebaseDB.test.ts
+++ b/api/database/firebaseDB.test.ts
@@ -36,6 +36,8 @@ function setNestedValue(path: string, value: unknown): void {
 }
 
 let pushCounter = 0;
+let setCallCount = 0;
+let updateCallCount = 0;
 
 function createMockRef(path: string): Record<string, unknown> {
   return {
@@ -73,9 +75,11 @@ function createMockRef(path: string): Record<string, unknown> {
       };
     }),
     set: vi.fn(async (value: unknown) => {
+      setCallCount++;
       setNestedValue(path, value);
     }),
     update: vi.fn(async (updates: Record<string, unknown>) => {
+      updateCallCount++;
       for (const [updatePath, value] of Object.entries(updates)) {
         setNestedValue(`${path}/${updatePath}`, value);
       }
@@ -110,6 +114,8 @@ describe("firebaseDB", () => {
   beforeEach(() => {
     store = {};
     pushCounter = 0;
+    setCallCount = 0;
+    updateCallCount = 0;
   });
 
   describe("getActivities — enrichment", () => {
@@ -215,6 +221,39 @@ describe("firebaseDB", () => {
       expect(activities!.act1.categoryId).toBe("catB");
       expect(activities!.act2.categoryId).toBe("catB");
     });
+
+    it("applies the move as a single atomic update (no sequential set writes)", async () => {
+      seedCategories({
+        catA: {
+          name: "Sports",
+          active: true,
+          description: "",
+          activityNames: ["Running", "Swimming"],
+        },
+        catB: {
+          name: "Other",
+          active: true,
+          description: "",
+          activityNames: ["Yoga"],
+        },
+      });
+
+      await firebaseDB.bulkReassignCategory(USER_ID, "catA", "catB");
+
+      // Atomicity: exactly one fan-out update(), zero direct set() writes
+      expect(updateCallCount).toBe(1);
+      expect(setCallCount).toBe(0);
+
+      const categories = getNestedValue(
+        `users/${USER_ID}/categories`
+      ) as CategoryMap;
+      expect(categories.catA.activityNames).toEqual([]);
+      expect(categories.catB.activityNames).toEqual([
+        "Yoga",
+        "Running",
+        "Swimming",
+      ]);
+    });
   });
 
   describe("bulkAssignCategory", () => {
@@ -249,6 +288,35 @@ describe("firebaseDB", () => {
       const activities = await firebaseDB.getActivities(USER_ID);
       expect(activities!.act1.categoryId).toBe("catB");
       expect(activities!.act1.active).toBe(false);
+    });
+
+    it("applies remove + add as a single atomic update (no sequential set writes)", async () => {
+      seedCategories({
+        catA: {
+          name: "Sports",
+          active: true,
+          description: "",
+          activityNames: ["Running", "Swimming"],
+        },
+        catB: {
+          name: "Other",
+          active: false,
+          description: "",
+          activityNames: [],
+        },
+      });
+
+      await firebaseDB.bulkAssignCategory(USER_ID, "Running", "catB");
+
+      // Atomicity: exactly one fan-out update(), zero direct set() writes
+      expect(updateCallCount).toBe(1);
+      expect(setCallCount).toBe(0);
+
+      const categories = getNestedValue(
+        `users/${USER_ID}/categories`
+      ) as CategoryMap;
+      expect(categories.catA.activityNames).toEqual(["Swimming"]);
+      expect(categories.catB.activityNames).toEqual(["Running"]);
     });
   });
 

--- a/api/database/firebaseDB.ts
+++ b/api/database/firebaseDB.ts
@@ -211,13 +211,16 @@ export const firebaseDB: Database = {
     const categories = catSnapshot.val() as CategoryMap | null;
     if (!categories) return;
 
+    const updates: Record<string, string[]> = {};
+
     // Remove from current category
     for (const [catId, cat] of Object.entries(categories)) {
       const names = cat.activityNames ?? [];
       const idx = names.indexOf(activityName);
       if (idx !== -1) {
-        const newNames = names.filter((n) => n !== activityName);
-        await categoriesRef.child(catId).child("activityNames").set(newNames);
+        updates[`${catId}/activityNames`] = names.filter(
+          (n) => n !== activityName
+        );
         break;
       }
     }
@@ -227,11 +230,15 @@ export const firebaseDB: Database = {
     if (targetCat) {
       const targetNames = targetCat.activityNames ?? [];
       if (!targetNames.includes(activityName)) {
-        await categoriesRef
-          .child(categoryId)
-          .child("activityNames")
-          .set([...targetNames, activityName]);
+        updates[`${categoryId}/activityNames`] = [
+          ...targetNames,
+          activityName,
+        ];
       }
+    }
+
+    if (Object.keys(updates).length > 0) {
+      await categoriesRef.update(updates);
     }
   },
 
@@ -252,14 +259,10 @@ export const firebaseDB: Database = {
     const targetNames = [
       ...new Set([...(toCat.activityNames ?? []), ...namesToMove]),
     ];
-    await categoriesRef
-      .child(toCategoryId)
-      .child("activityNames")
-      .set(targetNames);
-    await categoriesRef
-      .child(fromCategoryId)
-      .child("activityNames")
-      .set([]);
+    await categoriesRef.update({
+      [`${toCategoryId}/activityNames`]: targetNames,
+      [`${fromCategoryId}/activityNames`]: [],
+    });
   },
 
   deleteActivitiesByCategory: async (userId, categoryId) => {


### PR DESCRIPTION
## What
Two changes:
1. **Atomic bulk category operations** (`api/database/firebaseDB.ts`): `bulkAssignCategory` and `bulkReassignCategory` each performed multiple sequential `.set()` writes on different category paths. These are now a single atomic multi-path `update()` on `categoriesRef`.
2. **README auth-header fix** (`README.md`): the Authentication Flow section said the API reads the Firebase ID token from the `Authorization` header. The code actually reads it from the `x-auth-token` header (used across `api/functions/*`). Corrected the one sentence.

## Why
A crash between the sequential `.set()` writes left category `activityNames` in an inconsistent state (e.g. a name removed from its old category but never added to the new one, or moved into the target but not cleared from the source). A single Firebase multi-path `update()` applies all path changes atomically, eliminating that window. The README correction prevents confusion for anyone implementing/debugging auth against the API.

## How
- Build a `Record<string, string[]>` of relative paths (`${catId}/activityNames` → new names) and call `categoriesRef.update(updates)` exactly once per method, mirroring the existing fan-out pattern already used by `bulkRenameActivities` and `deleteActivitiesByCategory`.
- All existing guards and behavior preserved: early returns (no categories / missing target / empty source), `new Set` dedup, skip-if-already-present, and the "a name should only be in one category" break. Edge cases verified to produce identical final state to the old code — including same-category assign and `from === toCategoryId` reassign (colliding multi-path keys collapse last-wins, matching the old last-`.set()`-wins result).

## Test coverage
`api/database/firebaseDB.test.ts`:
- Extended the in-memory Firebase mock with `set`/`update` call counters (the mock's `update()` already fans out multi-path `/` keys via `setNestedValue`).
- Added atomicity tests for both methods asserting exactly **one** `update()` and **zero** `set()` writes plus correct final state.
- Added edge-case regression tests: same source/target reassign (key collision) and assigning a name that was in no category.

All 156 API tests pass; `bun run lint` (`--max-warnings=0`) and client `tsc --noEmit` are clean. Reviewed with a rubber-duck agent — no blocking issues; behavior preservation confirmed.