### PR TITLE
refactor: scope activities-limit query key, harden 500 errors, add apiClient wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,11 @@ cd api && bun run test            # Run API unit tests
 
 ## Testing
 
-**Client**: Storybook play functions as vitest tests via `@storybook/addon-vitest`. MSW mocks API. Use `@storybook/test` for assertions. Use deterministic data (seeded PRNG) for stable screenshot tests.
+**Client**: Two vitest projects run via `bun run test` (`vite.config.ts` → `test.projects`):
+- `storybook` (browser, Chromium): Storybook play functions as tests via `@storybook/addon-vitest`. MSW mocks API. Use `@storybook/test` for assertions. Use deterministic data (seeded PRNG) for stable screenshot tests. Stories live in `*.stories.tsx`.
+- `unit` (node): plain `*.test.ts(x)` files for pure logic that needs no DOM/browser (e.g. query options, `apiClient`). Stub `global.fetch` instead of MSW.
 
-**API**: Vitest unit tests for validation, rate limiting, database CRUD.
+**API**: Vitest unit tests for validation, rate limiting, database CRUD. Handler tests must mock `firebase/firebase` (and modules importing it) since it calls `initializeApp()` at load.
 
 All new code should include tests.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,11 @@ cd api && bun run test            # Run API unit tests
 
 ## Testing
 
-**Client**: Storybook play functions as vitest tests via `@storybook/addon-vitest`. MSW mocks API. Use `@storybook/test` for assertions. Use deterministic data (seeded PRNG) for stable screenshot tests.
+**Client**: Two vitest projects run via `bun run test` (`vite.config.ts` → `test.projects`):
+- `storybook` (browser, Chromium): Storybook play functions as tests via `@storybook/addon-vitest`. MSW mocks API. Use `@storybook/test` for assertions. Use deterministic data (seeded PRNG) for stable screenshot tests. Stories live in `*.stories.tsx`.
+- `unit` (node): plain `*.test.ts(x)` files for pure logic that needs no DOM/browser (e.g. query options, `apiClient`). Stub `global.fetch` instead of MSW.
 
-**API**: Vitest unit tests for validation, rate limiting, database CRUD.
+**API**: Vitest unit tests for validation, rate limiting, database CRUD. Handler tests must mock `firebase/firebase` (and modules importing it) since it calls `initializeApp()` at load.
 
 All new code should include tests.
 

--- a/api/functions/addActivity/index.test.ts
+++ b/api/functions/addActivity/index.test.ts
@@ -1,0 +1,63 @@
+import type { HttpRequest } from "@azure/functions";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@azure/functions", () => ({
+  app: { http: vi.fn() },
+}));
+
+vi.mock("../../authorization/firebaseAuthorization", () => ({
+  getUserId: vi.fn(async () => "user-1"),
+}));
+
+vi.mock("../../rateLimit/rateLimiter", () => ({
+  checkRateLimit: vi.fn(async () => ({ allowed: true })),
+  getRateLimitHeaders: vi.fn(() => ({})),
+}));
+
+vi.mock("../../validation/validators", () => ({
+  validateActivityBatch: vi.fn(() => ({
+    valid: true,
+    data: [{ name: "Running", date: "2024-01-01" }],
+  })),
+}));
+
+const { addActivities, getActivityCount } = vi.hoisted(() => ({
+  addActivities: vi.fn(),
+  getActivityCount: vi.fn(async () => 0),
+}));
+
+vi.mock("../../database/firebaseDB", () => ({
+  firebaseDB: {
+    getActivityCount,
+    addActivities,
+  },
+}));
+
+import { addActivity } from "./index";
+
+function makeRequest(): HttpRequest {
+  return {
+    json: async () => [{ name: "Running", date: "2024-01-01" }],
+    headers: {
+      get: (name: string) => (name === "x-auth-token" ? "valid-token" : null),
+    },
+  } as unknown as HttpRequest;
+}
+
+describe("addActivity error handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getActivityCount.mockResolvedValue(0);
+  });
+
+  it("returns a generic 500 body without leaking the internal error message", async () => {
+    const secret = "Firebase connection string leaked: super-secret";
+    addActivities.mockRejectedValueOnce(new Error(secret));
+
+    const response = await addActivity(makeRequest());
+
+    expect(response.status).toBe(500);
+    expect(response.body).toBe("Internal server error");
+    expect(response.body).not.toContain("secret");
+  });
+});

--- a/api/functions/addActivity/index.test.ts
+++ b/api/functions/addActivity/index.test.ts
@@ -1,6 +1,10 @@
 import type { HttpRequest } from "@azure/functions";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// These modules transitively import firebase/firebase.ts, which calls
+// initializeApp() at load time and would crash without real credentials, so
+// they must be stubbed. validateActivityBatch is pure and is intentionally
+// NOT mocked — the test exercises the real validation path with valid data.
 vi.mock("@azure/functions", () => ({
   app: { http: vi.fn() },
 }));
@@ -12,13 +16,6 @@ vi.mock("../../authorization/firebaseAuthorization", () => ({
 vi.mock("../../rateLimit/rateLimiter", () => ({
   checkRateLimit: vi.fn(async () => ({ allowed: true })),
   getRateLimitHeaders: vi.fn(() => ({})),
-}));
-
-vi.mock("../../validation/validators", () => ({
-  validateActivityBatch: vi.fn(() => ({
-    valid: true,
-    data: [{ name: "Running", date: "2024-01-01" }],
-  })),
 }));
 
 const { addActivities, getActivityCount } = vi.hoisted(() => ({
@@ -35,9 +32,11 @@ vi.mock("../../database/firebaseDB", () => ({
 
 import { addActivity } from "./index";
 
+const validActivities = [{ name: "Running", date: "2024-01-01" }];
+
 function makeRequest(): HttpRequest {
   return {
-    json: async () => [{ name: "Running", date: "2024-01-01" }],
+    json: async () => validActivities,
     headers: {
       get: (name: string) => (name === "x-auth-token" ? "valid-token" : null),
     },
@@ -51,13 +50,14 @@ describe("addActivity error handling", () => {
   });
 
   it("returns a generic 500 body without leaking the internal error message", async () => {
-    const secret = "Firebase connection string leaked: super-secret";
-    addActivities.mockRejectedValueOnce(new Error(secret));
+    const internalMessage =
+      "Firebase connection string: postgres://admin:super-secret@db";
+    addActivities.mockRejectedValueOnce(new Error(internalMessage));
 
     const response = await addActivity(makeRequest());
 
     expect(response.status).toBe(500);
     expect(response.body).toBe("Internal server error");
-    expect(response.body).not.toContain("secret");
+    expect(response.body).not.toContain(internalMessage);
   });
 });

--- a/api/functions/addActivity/index.ts
+++ b/api/functions/addActivity/index.ts
@@ -8,7 +8,9 @@ import {
 import { LIMITS } from "../../validation/constants";
 import { validateActivityBatch } from "../../validation/validators";
 
-async function addActivity(request: HttpRequest): Promise<HttpResponseInit> {
+export async function addActivity(
+  request: HttpRequest
+): Promise<HttpResponseInit> {
   let activities: unknown;
   try {
     activities = await request.json();
@@ -58,9 +60,10 @@ async function addActivity(request: HttpRequest): Promise<HttpResponseInit> {
       body: "Successfully added",
     };
   } catch (err) {
+    console.error("addActivity error:", err);
     return {
       status: 500,
-      body: (err as Error).message,
+      body: "Internal server error",
     };
   }
 }

--- a/api/functions/addCategory/index.test.ts
+++ b/api/functions/addCategory/index.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // initializeApp() at load time and would crash without real credentials, so
 // they must be stubbed. firebase/firebase is also mocked directly so the test
 // stays safe if index.ts (or a helper) ever imports it directly.
-// validateActivityBatch is pure and is intentionally NOT mocked — the test
+// validateCategory is pure and is intentionally NOT mocked — the test
 // exercises the real validation path with valid data.
 vi.mock("@azure/functions", () => ({
   app: { http: vi.fn() },
@@ -25,43 +25,48 @@ vi.mock("../../rateLimit/rateLimiter", () => ({
   getRateLimitHeaders: vi.fn(() => ({})),
 }));
 
-const { addActivities, getActivityCount } = vi.hoisted(() => ({
-  addActivities: vi.fn(),
-  getActivityCount: vi.fn(async () => 0),
+const { addCategory: addCategoryDb, getCategoryCount } = vi.hoisted(() => ({
+  addCategory: vi.fn(),
+  getCategoryCount: vi.fn(async () => 0),
 }));
 
 vi.mock("../../database/firebaseDB", () => ({
   firebaseDB: {
-    getActivityCount,
-    addActivities,
+    getCategoryCount,
+    addCategory: addCategoryDb,
   },
 }));
 
-import { addActivity } from "./index";
+import { addCategory } from "./index";
 
-const validActivities = [{ name: "Running", date: "2024-01-01" }];
+const validCategory = {
+  name: "Sports",
+  description: "Physical activities",
+  active: true,
+  activityNames: ["Running"],
+};
 
 function makeRequest(): HttpRequest {
   return {
-    json: async () => validActivities,
+    json: async () => validCategory,
     headers: {
       get: (name: string) => (name === "x-auth-token" ? "valid-token" : null),
     },
   } as unknown as HttpRequest;
 }
 
-describe("addActivity error handling", () => {
+describe("addCategory error handling", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    getActivityCount.mockResolvedValue(0);
+    getCategoryCount.mockResolvedValue(0);
   });
 
   it("returns a generic 500 body without leaking the internal error message", async () => {
     const internalMessage =
       "Firebase connection string: postgres://admin:super-secret@db";
-    addActivities.mockRejectedValueOnce(new Error(internalMessage));
+    addCategoryDb.mockRejectedValueOnce(new Error(internalMessage));
 
-    const response = await addActivity(makeRequest());
+    const response = await addCategory(makeRequest());
 
     expect(response.status).toBe(500);
     expect(response.body).toBe("Internal server error");

--- a/api/functions/addCategory/index.ts
+++ b/api/functions/addCategory/index.ts
@@ -53,9 +53,10 @@ async function addCategory(request: HttpRequest): Promise<HttpResponseInit> {
       body: "Successfully added",
     };
   } catch (err) {
+    console.error("addCategory error:", err);
     return {
       status: 500,
-      body: (err as Error).message,
+      body: "Internal server error",
     };
   }
 }

--- a/api/functions/addCategory/index.ts
+++ b/api/functions/addCategory/index.ts
@@ -8,7 +8,9 @@ import {
 import { LIMITS } from "../../validation/constants";
 import { validateCategory } from "../../validation/validators";
 
-async function addCategory(request: HttpRequest): Promise<HttpResponseInit> {
+export async function addCategory(
+  request: HttpRequest
+): Promise<HttpResponseInit> {
   let category: unknown;
   try {
     category = await request.json();

--- a/client/src/app/routes/activity-list.tsx
+++ b/client/src/app/routes/activity-list.tsx
@@ -1,4 +1,5 @@
 import { RouteErrorBoundary } from "../../components/states/RouteErrorBoundary";
+import { apiFetch } from "../../data/apiClient";
 import {
   activitiesQueryOptions,
   categoriesQueryOptions,
@@ -24,19 +25,16 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   const { queryClient, getAuthToken } = getLoadContext();
   const formData = await request.formData();
   const intent = formData.get("intent");
-  const token = await getAuthToken();
 
   if (intent === "edit") {
     const id = formData.get("id") as string;
     const record = JSON.parse(formData.get("record") as string);
 
-    const response = await fetch(`/api/activities/${id}`, {
+    const response = await apiFetch(getAuthToken, `/api/activities/${id}`, {
       method: "PUT",
-      headers: {
-        "x-auth-token": token,
-        "Content-Type": "application/json",
-      },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(record),
+      allowNotOk: true,
     });
 
     if (!response.ok) {
@@ -45,18 +43,18 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   } else if (intent === "delete") {
     const id = formData.get("id") as string;
 
-    const response = await fetch(`/api/activities/${id}`, {
+    const response = await apiFetch(getAuthToken, `/api/activities/${id}`, {
       method: "DELETE",
-      headers: { "x-auth-token": token },
+      allowNotOk: true,
     });
 
     if (!response.ok) {
       return { error: `HTTP error! status: ${response.status}` };
     }
   } else if (intent === "delete-all") {
-    const response = await fetch("/api/activities", {
+    const response = await apiFetch(getAuthToken, "/api/activities", {
       method: "DELETE",
-      headers: { "x-auth-token": token },
+      allowNotOk: true,
     });
 
     if (!response.ok) {
@@ -65,13 +63,11 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   } else if (intent === "import") {
     const importData = JSON.parse(formData.get("importData") as string);
 
-    const response = await fetch("/api/import", {
+    const response = await apiFetch(getAuthToken, "/api/import", {
       method: "POST",
-      headers: {
-        "x-auth-token": token,
-        "Content-Type": "application/json",
-      },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(importData),
+      allowNotOk: true,
     });
 
     if (!response.ok) {

--- a/client/src/data/apiClient.test.ts
+++ b/client/src/data/apiClient.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { apiFetch } from "./apiClient";
+
+describe("apiFetch", () => {
+  const getAuthToken = async () => "test-token";
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const mockFetch = (response: Response) =>
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+
+  it("injects the x-auth-token header from getAuthToken", async () => {
+    const fetchMock = mockFetch(new Response(null, { status: 200 }));
+
+    await apiFetch(getAuthToken, "/api/activities");
+
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = new Headers(init?.headers);
+    expect(headers.get("x-auth-token")).toBe("test-token");
+  });
+
+  it("preserves caller headers and init while still setting the auth token", async () => {
+    const fetchMock = mockFetch(new Response(null, { status: 200 }));
+
+    await apiFetch(getAuthToken, "/api/activities", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = new Headers(init?.headers);
+    expect(headers.get("content-type")).toBe("application/json");
+    expect(headers.get("x-auth-token")).toBe("test-token");
+    expect(init?.method).toBe("PUT");
+  });
+
+  it("throws on a non-ok response by default", async () => {
+    mockFetch(new Response(null, { status: 500 }));
+
+    await expect(apiFetch(getAuthToken, "/api/activities")).rejects.toThrow(
+      "HTTP error! status: 500"
+    );
+  });
+
+  it("returns the response without throwing when allowNotOk is set (preferences default-on-error path)", async () => {
+    mockFetch(new Response(null, { status: 404 }));
+
+    const response = await apiFetch(getAuthToken, "/api/preferences", {
+      allowNotOk: true,
+    });
+
+    expect(response.ok).toBe(false);
+    expect(response.status).toBe(404);
+  });
+});

--- a/client/src/data/apiClient.ts
+++ b/client/src/data/apiClient.ts
@@ -1,0 +1,38 @@
+export type GetAuthToken = () => Promise<string>;
+
+type ApiFetchOptions = RequestInit & {
+  /**
+   * When true the response is returned even on a non-ok status, so the caller
+   * can inspect `response.ok` itself (e.g. to fall back to a default value or
+   * build its own error result). Defaults to false, which throws on non-ok.
+   */
+  allowNotOk?: boolean;
+};
+
+/**
+ * Thin `fetch` wrapper that injects the `x-auth-token` header from
+ * `getAuthToken` and centralizes the repeated non-ok handling. Throws on a
+ * non-ok response by default; pass `allowNotOk: true` to handle the status
+ * manually.
+ */
+export async function apiFetch(
+  getAuthToken: GetAuthToken,
+  input: string,
+  { allowNotOk = false, headers, ...init }: ApiFetchOptions = {}
+): Promise<Response> {
+  const token = await getAuthToken();
+
+  const requestHeaders = new Headers(headers);
+  requestHeaders.set("x-auth-token", token);
+
+  const response = await fetch(input, {
+    ...init,
+    headers: requestHeaders,
+  });
+
+  if (!allowNotOk && !response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  return response;
+}

--- a/client/src/data/queryOptions.test.ts
+++ b/client/src/data/queryOptions.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { activitiesWithLimitQueryOptions } from "./queryOptions";
+
+describe("activitiesWithLimitQueryOptions", () => {
+  const getAuthToken = async () => "token";
+
+  it("includes the limit in the query key so different limits don't collide in the cache", () => {
+    expect(activitiesWithLimitQueryOptions(getAuthToken, 5).queryKey).toEqual([
+      "activitiesWithLimit",
+      5,
+    ]);
+    expect(activitiesWithLimitQueryOptions(getAuthToken, 10).queryKey).toEqual([
+      "activitiesWithLimit",
+      10,
+    ]);
+  });
+
+  it("keeps 'activitiesWithLimit' as the key prefix so partial-key invalidation still matches", () => {
+    const { queryKey } = activitiesWithLimitQueryOptions(getAuthToken, 5);
+    expect(queryKey[0]).toBe("activitiesWithLimit");
+  });
+});

--- a/client/src/data/queryOptions.ts
+++ b/client/src/data/queryOptions.ts
@@ -1,4 +1,5 @@
 import { queryOptions } from "@tanstack/react-query";
+import { apiFetch, type GetAuthToken } from "./apiClient";
 import {
   activitiesApiPath,
   categoriesApiPath,
@@ -15,27 +16,16 @@ import type {
   UserPreferences,
 } from "./types";
 
-type GetAuthToken = () => Promise<string>;
-
 const fetchActivities = async (
   getAuthToken: GetAuthToken,
   limit?: number
 ): Promise<ActivityRecordWithId[]> => {
-  const token = await getAuthToken();
-
   const url = new URL(activitiesApiPath, window.location.origin);
   if (limit) {
     url.searchParams.append("limit", String(limit));
   }
 
-  const response = await fetch(url.toString(), {
-    method: "GET",
-    headers: { "x-auth-token": token },
-  });
-
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
+  const response = await apiFetch(getAuthToken, url.toString());
 
   const activityRecordsResponse =
     (await response.json()) as ActivityRecordWithIdServer[];
@@ -49,16 +39,7 @@ const fetchActivities = async (
 const fetchCategories = async (
   getAuthToken: GetAuthToken
 ): Promise<Category[]> => {
-  const token = await getAuthToken();
-
-  const response = await fetch(categoriesApiPath, {
-    method: "GET",
-    headers: { "x-auth-token": token },
-  });
-
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
+  const response = await apiFetch(getAuthToken, categoriesApiPath);
 
   return (await response.json()) as Category[];
 };
@@ -74,7 +55,7 @@ export const activitiesWithLimitQueryOptions = (
   limit = 5
 ) =>
   queryOptions({
-    queryKey: [...getActivitiesQueryIdWithLimit],
+    queryKey: [...getActivitiesQueryIdWithLimit, limit],
     queryFn: () => fetchActivities(getAuthToken, limit),
   });
 
@@ -93,10 +74,8 @@ const DEFAULT_PREFERENCES: UserPreferences = {
 const fetchPreferences = async (
   getAuthToken: GetAuthToken
 ): Promise<UserPreferences> => {
-  const token = await getAuthToken();
-  const response = await fetch(preferencesApiPath, {
-    method: "GET",
-    headers: { "x-auth-token": token },
+  const response = await apiFetch(getAuthToken, preferencesApiPath, {
+    allowNotOk: true,
   });
 
   if (!response.ok) {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -135,6 +135,14 @@ export default defineConfig(async (): Promise<UserConfig> => {
       projects: [
         {
           extends: true,
+          test: {
+            name: "unit",
+            include: ["src/**/*.test.{ts,tsx}"],
+            environment: "node",
+          },
+        },
+        {
+          extends: true,
           plugins: [
             // The plugin will run tests for the stories defined in your Storybook config
             // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest


### PR DESCRIPTION
Three small, related robustness / code-quality changes. Scoped to the files listed below.

## Change 1 — Include `limit` in the activities-with-limit query key
**What:** `activitiesWithLimitQueryOptions` now uses `queryKey: ["activitiesWithLimit", limit]` instead of just `["activitiesWithLimit"]`.
**Why:** The `limit` was not part of the cache key, so different limits would collide in the React Query cache.
**How:** Append `limit` to the key in `client/src/data/queryOptions.ts`. Invalidation is unaffected: every call site invalidates with the partial key `["activitiesWithLimit"]`, and React Query v5 does **prefix** matching by default, so it still invalidates all limit variants (`["activitiesWithLimit", 5]`, etc.).

## Change 2 — Stop leaking internal error messages on 500
**What:** `addActivity` and `addCategory` now `console.error(...)` and return `{ status: 500, body: "Internal server error" }` instead of `(err as Error).message`.
**Why:** Returning the raw error message leaks internal details to clients.
**How:** Match the pattern already used by `importData` / `addActivityNameToCategory`. All 400 validation messages and 401 auth messages are preserved exactly. `addActivityNameToCategory` was already hardened (it returns 400 for the user-facing `"already belongs to"` / `"not found"` business errors and a generic 500 otherwise) and is intentionally left unchanged.

## Change 3 — Extract a small `apiClient` wrapper for repeated fetch boilerplate
**What:** New `client/src/data/apiClient.ts` exposes `apiFetch(getAuthToken, input, opts)` that injects the `x-auth-token` header and centralizes `!response.ok` handling (throws by default; `allowNotOk: true` returns the response for manual handling).
**Why:** The `getAuthToken` → `fetch` with auth header → `!ok` check pattern was duplicated across `queryOptions.ts` fetchers and the `activity-list` `clientAction`.
**How:** Refactored `fetchActivities`, `fetchCategories`, and `fetchPreferences` plus the `activity-list` `clientAction` (edit/delete/delete-all/import) to use it. Constraints honored:
- `fetchPreferences` keeps returning `DEFAULT_PREFERENCES` on `!ok` via the `allowNotOk` opt-out (no throw).
- `clientAction` keeps identical `{ error: \`HTTP error! status: ... \` }` / `{ ok: true }` return shapes and unchanged invalidations.
- Settings/Welcome flows were left untouched (out of scope for this PR).
- Header merging uses `Headers` so the auth token is always present as a single, case-insensitive header regardless of caller header shape.

## Test notes
- **API:** new `api/functions/addActivity/index.test.ts` asserts a thrown DB error yields a generic `500 / "Internal server error"` body and does not leak the underlying message. `cd api && bun run test` → 153 passed.
- **Client:** existing Storybook tests cover the refactored `clientAction` (edit/delete/delete-all/import/export). `cd client && bunx vitest run` → 71 passed.
- `bun run lint` and `cd client && bunx tsc --noEmit` both clean. (The pre-existing `api` `tsc` error about the gitignored `firebaseConfig.json` is unrelated to this PR.)

Reviewed with a rubber-duck pass: confirmed prefix invalidation still works, no error messages leak, and the wrapper preserves the preferences-default and `clientAction` return shapes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared authenticated request helper for client data fetching.
  * Introduced a separate Node-based test project for unit tests alongside Storybook tests.

* **Bug Fixes**
  * Server errors now return a generic message instead of exposing internal details.
  * Activity, category, and preference requests now use the shared request helper consistently.
  * Query keys for limited activity results now include the limit value to avoid cache mix-ups.

* **Tests**
  * Added coverage for authenticated requests, query key behavior, and error handling on server endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->