### PR TITLE
feat: weekly activity heatmap on the dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ cd api && bun run test            # Run API unit tests
 
 - `app/routes/` — Route modules with loaders/actions. `_layout.tsx` is the auth guard wrapper.
 - `components/ui/` — shadcn/ui primitives (no stories or tests needed for these)
-- `components/` — Domain components: `forms/`, `table/EditableTableRow/`, `visualization/`, `navigation/`, `states/`, `styles/`
+- `components/` — Domain components: `forms/`, `table/EditableTableRow/`, `visualization/` (incl. `WeeklyHeatmap/` — 52-week activity heatmap on the dashboard), `navigation/`, `states/`, `styles/`
 - `data/` — React Query hooks, API functions, types (`types.ts`), Zod validation
 - `pages/` — Page components + split utility modules (e.g., `compare-utils.ts`, `PeriodSelector.tsx`, settings tabs)
 - `mocks/` — MSW handlers and mock data for Storybook

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ cd api && bun run test            # Run API unit tests
 
 - `app/routes/` — Route modules with loaders/actions. `_layout.tsx` is the auth guard wrapper.
 - `components/ui/` — shadcn/ui primitives (no stories or tests needed for these)
-- `components/` — Domain components: `forms/`, `table/EditableTableRow/`, `visualization/`, `navigation/`, `states/`, `styles/`
+- `components/` — Domain components: `forms/`, `table/EditableTableRow/`, `visualization/` (incl. `WeeklyHeatmap/` — 52-week activity heatmap on the dashboard), `navigation/`, `states/`, `styles/`
 - `data/` — React Query hooks, API functions, types (`types.ts`), Zod validation
 - `pages/` — Page components + split utility modules (e.g., `compare-utils.ts`, `PeriodSelector.tsx`, settings tabs)
 - `mocks/` — MSW handlers and mock data for Storybook

--- a/client/src/components/ui/tooltip.tsx
+++ b/client/src/components/ui/tooltip.tsx
@@ -1,6 +1,8 @@
 import { Tooltip as TooltipPrimitive } from "radix-ui";
 import * as React from "react";
 
+import { cn } from "@/utils/cn";
+
 function TooltipProvider({
   delayDuration = 0,
   ...props
@@ -14,4 +16,44 @@ function TooltipProvider({
   );
 }
 
-export { TooltipProvider };
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  );
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/client/src/components/visualization/WeeklyHeatmap/HeatmapCell.tsx
+++ b/client/src/components/visualization/WeeklyHeatmap/HeatmapCell.tsx
@@ -1,0 +1,46 @@
+import { format } from "date-fns";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/utils/cn";
+import { levelBackground } from "./heatmap-colors";
+import type { WeeklyBucket } from "./weekly-heatmap-data";
+
+type HeatmapCellProps = {
+  bucket: WeeklyBucket;
+};
+
+function activityLabel(count: number): string {
+  return `${count} ${count === 1 ? "activity" : "activities"}`;
+}
+
+export function HeatmapCell({ bucket }: HeatmapCellProps) {
+  const weekOf = format(bucket.weekStart, "MMM d, yyyy");
+  const range = `${format(bucket.weekStart, "MMM d")} – ${format(
+    bucket.weekEnd,
+    "MMM d, yyyy"
+  )}`;
+  const label = `Week of ${weekOf}: ${activityLabel(bucket.count)}`;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        type="button"
+        aria-label={label}
+        data-level={bucket.level}
+        className={cn(
+          "size-[16px] rounded-[3px] shadow-[inset_0_0_0_1px_rgba(0,0,0,0.06)]",
+          "outline-none transition-transform focus-visible:ring-2 focus-visible:ring-ring",
+          "focus-visible:ring-offset-1 focus-visible:ring-offset-background hover:scale-110"
+        )}
+        style={{ backgroundColor: levelBackground(bucket.level) }}
+      />
+      <TooltipContent>
+        <span className="font-medium">{range}</span>
+        <span className="block tabular-nums">{activityLabel(bucket.count)}</span>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/client/src/components/visualization/WeeklyHeatmap/HeatmapCell.tsx
+++ b/client/src/components/visualization/WeeklyHeatmap/HeatmapCell.tsx
@@ -5,7 +5,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/utils/cn";
-import { levelBackground } from "./heatmap-colors";
+import { levelStyle } from "./heatmap-colors";
 import type { WeeklyBucket } from "./weekly-heatmap-data";
 
 type HeatmapCellProps = {
@@ -31,11 +31,11 @@ export function HeatmapCell({ bucket }: HeatmapCellProps) {
         aria-label={label}
         data-level={bucket.level}
         className={cn(
-          "size-[16px] rounded-[3px] shadow-[inset_0_0_0_1px_rgba(0,0,0,0.06)]",
+          "size-[16px] rounded-[3px]",
           "outline-hidden transition-transform focus-visible:ring-2 focus-visible:ring-ring",
           "focus-visible:ring-offset-1 focus-visible:ring-offset-background hover:scale-110"
         )}
-        style={{ backgroundColor: levelBackground(bucket.level) }}
+        style={levelStyle(bucket.level)}
       />
       <TooltipContent>
         <span className="font-medium">{range}</span>

--- a/client/src/components/visualization/WeeklyHeatmap/HeatmapCell.tsx
+++ b/client/src/components/visualization/WeeklyHeatmap/HeatmapCell.tsx
@@ -32,7 +32,7 @@ export function HeatmapCell({ bucket }: HeatmapCellProps) {
         data-level={bucket.level}
         className={cn(
           "size-[16px] rounded-[3px] shadow-[inset_0_0_0_1px_rgba(0,0,0,0.06)]",
-          "outline-none transition-transform focus-visible:ring-2 focus-visible:ring-ring",
+          "outline-hidden transition-transform focus-visible:ring-2 focus-visible:ring-ring",
           "focus-visible:ring-offset-1 focus-visible:ring-offset-background hover:scale-110"
         )}
         style={{ backgroundColor: levelBackground(bucket.level) }}

--- a/client/src/components/visualization/WeeklyHeatmap/HeatmapLegend.tsx
+++ b/client/src/components/visualization/WeeklyHeatmap/HeatmapLegend.tsx
@@ -1,0 +1,20 @@
+import { HEATMAP_LEVELS, levelBackground } from "./heatmap-colors";
+
+export function HeatmapLegend() {
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      <span>Less</span>
+      <div className="flex items-center gap-1" aria-hidden="true">
+        {HEATMAP_LEVELS.map((level) => (
+          <span
+            key={level}
+            data-level={level}
+            className="size-[12px] rounded-[3px] shadow-[inset_0_0_0_1px_rgba(0,0,0,0.06)]"
+            style={{ backgroundColor: levelBackground(level) }}
+          />
+        ))}
+      </div>
+      <span>More</span>
+    </div>
+  );
+}

--- a/client/src/components/visualization/WeeklyHeatmap/HeatmapLegend.tsx
+++ b/client/src/components/visualization/WeeklyHeatmap/HeatmapLegend.tsx
@@ -1,4 +1,4 @@
-import { HEATMAP_LEVELS, levelBackground } from "./heatmap-colors";
+import { HEATMAP_LEVELS, levelStyle } from "./heatmap-colors";
 
 export function HeatmapLegend() {
   return (
@@ -9,8 +9,8 @@ export function HeatmapLegend() {
           <span
             key={level}
             data-level={level}
-            className="size-[12px] rounded-[3px] shadow-[inset_0_0_0_1px_rgba(0,0,0,0.06)]"
-            style={{ backgroundColor: levelBackground(level) }}
+            className="size-[12px] rounded-[3px]"
+            style={levelStyle(level)}
           />
         ))}
       </div>

--- a/client/src/components/visualization/WeeklyHeatmap/WeeklyHeatmap.stories.tsx
+++ b/client/src/components/visualization/WeeklyHeatmap/WeeklyHeatmap.stories.tsx
@@ -89,5 +89,16 @@ export const Default: Story = {
     // The legend is present.
     expect(canvas.getByText("Less")).toBeInTheDocument();
     expect(canvas.getByText("More")).toBeInTheDocument();
+
+    // The group is described by the screen-reader summary (aria-describedby).
+    const group = canvas.getByRole("group", {
+      name: "Weekly activity heatmap, last 52 weeks",
+    });
+    const summaryId = group.getAttribute("aria-describedby");
+    expect(summaryId).toBeTruthy();
+    const summary = canvasElement.ownerDocument.getElementById(summaryId!);
+    expect(summary).toHaveTextContent(
+      /Weekly activity heatmap of the last 52 weeks/
+    );
   },
 };

--- a/client/src/components/visualization/WeeklyHeatmap/WeeklyHeatmap.stories.tsx
+++ b/client/src/components/visualization/WeeklyHeatmap/WeeklyHeatmap.stories.tsx
@@ -86,6 +86,19 @@ export const Default: Story = {
     });
     expect(busyWeek).toHaveAttribute("data-level", "3");
 
+    // Empty weeks (level 0) render HOLLOW — transparent fill — so they stay
+    // clearly distinct from level 1; active weeks are filled.
+    const emptyCells = cells.filter(
+      (cell) => cell.getAttribute("data-level") === "0"
+    );
+    expect(emptyCells.length).toBeGreaterThan(0);
+    for (const cell of emptyCells) {
+      expect((cell as HTMLElement).style.backgroundColor).toBe("transparent");
+    }
+    expect((busyWeek as HTMLElement).style.backgroundColor).not.toBe(
+      "transparent"
+    );
+
     // The legend is present.
     expect(canvas.getByText("Less")).toBeInTheDocument();
     expect(canvas.getByText("More")).toBeInTheDocument();

--- a/client/src/components/visualization/WeeklyHeatmap/WeeklyHeatmap.stories.tsx
+++ b/client/src/components/visualization/WeeklyHeatmap/WeeklyHeatmap.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { addDays, startOfWeek, subWeeks } from "date-fns";
+import { expect, within } from "storybook/test";
+import { HeatmapLegend } from "./HeatmapLegend";
+import { WeeklyHeatmap } from "./WeeklyHeatmap";
+import {
+  buildWeeklyHeatmap,
+  type HeatmapActivity,
+} from "./weekly-heatmap-data";
+
+/** Deterministic PRNG so the rendered heatmap (and screenshots) stay stable. */
+function mulberry32(seed: number): () => number {
+  let state = seed;
+  return () => {
+    state |= 0;
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const END_DATE = new Date(2024, 5, 15, 12); // Sat Jun 15 2024
+const LATEST_MONDAY = startOfWeek(END_DATE, { weekStartsOn: 1 }); // Mon Jun 10 2024
+
+function activitiesInWeek(offsetFromLatest: number, count: number) {
+  const weekStart = subWeeks(LATEST_MONDAY, offsetFromLatest);
+  const midWeek = addDays(weekStart, 2); // keep it comfortably inside the week
+  return Array.from(
+    { length: count },
+    (): HeatmapActivity => ({ date: new Date(midWeek), active: true })
+  );
+}
+
+function seededActivities(): HeatmapActivity[] {
+  const random = mulberry32(42);
+  const activities: HeatmapActivity[] = [
+    ...activitiesInWeek(0, 6), // latest week: 6 -> level 3 (asserted)
+    ...activitiesInWeek(1, 2), // -> level 1
+    ...activitiesInWeek(5, 9), // a clearly "max" week -> level 4
+  ];
+  for (let offset = 8; offset < 52; offset++) {
+    const count = Math.floor(random() * 5); // 0–4
+    activities.push(...activitiesInWeek(offset, count));
+  }
+  // An inactive activity in the latest week must NOT change the count.
+  activities.push({ date: new Date(addDays(LATEST_MONDAY, 2)), active: false });
+  return activities;
+}
+
+const buckets = buildWeeklyHeatmap(seededActivities(), {
+  endDate: END_DATE,
+  weeks: 52,
+});
+
+function HeatmapPreview() {
+  return (
+    <div className="max-w-2xl rounded-lg border bg-card p-4">
+      <WeeklyHeatmap buckets={buckets} />
+      <div className="mt-3 flex justify-end">
+        <HeatmapLegend />
+      </div>
+    </div>
+  );
+}
+
+const meta: Meta<typeof HeatmapPreview> = {
+  title: "Visualization/WeeklyHeatmap",
+  component: HeatmapPreview,
+};
+
+export default meta;
+type Story = StoryObj<typeof HeatmapPreview>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Exactly 52 week cells render (one focusable button per week).
+    const cells = canvas.getAllByRole("button");
+    expect(cells).toHaveLength(52);
+
+    // The known busy week has the expected level and accessible label.
+    const busyWeek = canvas.getByRole("button", {
+      name: "Week of Jun 10, 2024: 6 activities",
+    });
+    expect(busyWeek).toHaveAttribute("data-level", "3");
+
+    // The legend is present.
+    expect(canvas.getByText("Less")).toBeInTheDocument();
+    expect(canvas.getByText("More")).toBeInTheDocument();
+  },
+};

--- a/client/src/components/visualization/WeeklyHeatmap/WeeklyHeatmap.stories.tsx
+++ b/client/src/components/visualization/WeeklyHeatmap/WeeklyHeatmap.stories.tsx
@@ -94,6 +94,11 @@ export const Default: Story = {
     expect(emptyCells.length).toBeGreaterThan(0);
     for (const cell of emptyCells) {
       expect((cell as HTMLElement).style.backgroundColor).toBe("transparent");
+      // The hollow ring is a border, not an inline box-shadow — otherwise it
+      // would override the Tailwind focus-visible:ring-* and hide the keyboard
+      // focus indicator on empty cells.
+      expect((cell as HTMLElement).style.boxShadow).toBe("");
+      expect((cell as HTMLElement).style.border).not.toBe("");
     }
     expect((busyWeek as HTMLElement).style.backgroundColor).not.toBe(
       "transparent"

--- a/client/src/components/visualization/WeeklyHeatmap/WeeklyHeatmap.tsx
+++ b/client/src/components/visualization/WeeklyHeatmap/WeeklyHeatmap.tsx
@@ -1,4 +1,5 @@
 import { format } from "date-fns";
+import { useId } from "react";
 import { HeatmapCell } from "./HeatmapCell";
 import { getMonthLabels, type WeeklyBucket } from "./weekly-heatmap-data";
 
@@ -27,14 +28,18 @@ function buildSummary(buckets: WeeklyBucket[]): string {
 export function WeeklyHeatmap({ buckets, monthLabels }: WeeklyHeatmapProps) {
   const labels = monthLabels ?? getMonthLabels(buckets);
   const gridTemplateColumns = `repeat(${buckets.length}, ${CELL_PX}px)`;
+  const summaryId = useId();
 
   return (
     <div className="overflow-x-auto pb-1">
-      <p className="sr-only">{buildSummary(buckets)}</p>
+      <p id={summaryId} className="sr-only">
+        {buildSummary(buckets)}
+      </p>
       <div
         className="inline-flex flex-col gap-1"
         role="group"
         aria-label={`Weekly activity heatmap, last ${buckets.length} weeks`}
+        aria-describedby={summaryId}
       >
         <div
           className="grid h-4 items-end text-[10px] leading-none text-muted-foreground"

--- a/client/src/components/visualization/WeeklyHeatmap/WeeklyHeatmap.tsx
+++ b/client/src/components/visualization/WeeklyHeatmap/WeeklyHeatmap.tsx
@@ -1,0 +1,64 @@
+import { format } from "date-fns";
+import { HeatmapCell } from "./HeatmapCell";
+import { getMonthLabels, type WeeklyBucket } from "./weekly-heatmap-data";
+
+const CELL_PX = 16;
+const GAP_PX = 4;
+
+type WeeklyHeatmapProps = {
+  buckets: WeeklyBucket[];
+  monthLabels?: (string | null)[];
+};
+
+function buildSummary(buckets: WeeklyBucket[]): string {
+  const total = buckets.reduce((sum, bucket) => sum + bucket.count, 0);
+  if (total === 0) {
+    return `Weekly activity heatmap. No active activities in the last ${buckets.length} weeks.`;
+  }
+  const busiest = buckets.reduce((max, bucket) =>
+    bucket.count > max.count ? bucket : max
+  );
+  return `Weekly activity heatmap of the last ${buckets.length} weeks. ${total} active activities total. Busiest week of ${format(
+    busiest.weekStart,
+    "MMM d, yyyy"
+  )} with ${busiest.count} activities.`;
+}
+
+export function WeeklyHeatmap({ buckets, monthLabels }: WeeklyHeatmapProps) {
+  const labels = monthLabels ?? getMonthLabels(buckets);
+  const gridTemplateColumns = `repeat(${buckets.length}, ${CELL_PX}px)`;
+
+  return (
+    <div className="overflow-x-auto pb-1">
+      <p className="sr-only">{buildSummary(buckets)}</p>
+      <div
+        className="inline-flex flex-col gap-1"
+        role="group"
+        aria-label={`Weekly activity heatmap, last ${buckets.length} weeks`}
+      >
+        <div
+          className="grid h-4 items-end text-[10px] leading-none text-muted-foreground"
+          style={{ gridTemplateColumns, columnGap: `${GAP_PX}px` }}
+          aria-hidden="true"
+        >
+          {labels.map((label, index) => (
+            <span
+              key={index}
+              className="overflow-visible whitespace-nowrap"
+            >
+              {label}
+            </span>
+          ))}
+        </div>
+        <div
+          className="grid"
+          style={{ gridTemplateColumns, columnGap: `${GAP_PX}px` }}
+        >
+          {buckets.map((bucket) => (
+            <HeatmapCell key={bucket.weekStart.getTime()} bucket={bucket} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/visualization/WeeklyHeatmap/WeeklyHeatmap.tsx
+++ b/client/src/components/visualization/WeeklyHeatmap/WeeklyHeatmap.tsx
@@ -3,8 +3,9 @@ import { useId } from "react";
 import { HeatmapCell } from "./HeatmapCell";
 import { getMonthLabels, type WeeklyBucket } from "./weekly-heatmap-data";
 
-const CELL_PX = 16;
 const GAP_PX = 4;
+/** Vertical room reserved above every cell for the per-cell month label. */
+const LABEL_SPACE_PX = 16;
 
 type WeeklyHeatmapProps = {
   buckets: WeeklyBucket[];
@@ -27,42 +28,44 @@ function buildSummary(buckets: WeeklyBucket[]): string {
 
 export function WeeklyHeatmap({ buckets, monthLabels }: WeeklyHeatmapProps) {
   const labels = monthLabels ?? getMonthLabels(buckets);
-  const gridTemplateColumns = `repeat(${buckets.length}, ${CELL_PX}px)`;
   const summaryId = useId();
 
   return (
-    <div className="overflow-x-auto pb-1">
+    <div className="pb-1">
       <p id={summaryId} className="sr-only">
         {buildSummary(buckets)}
       </p>
+      {/*
+        Continuous strip that WRAPS instead of horizontal-scrolling: on wide
+        containers all 52 weeks sit on one GitHub-style row; on narrow screens
+        they flow onto further rows. Each month's first cell carries its own
+        label in the reserved space above it (absolute, relative to the cell),
+        so month markers stay correctly positioned no matter where they wrap.
+      */}
       <div
-        className="inline-flex flex-col gap-1"
+        className="flex flex-wrap"
         role="group"
         aria-label={`Weekly activity heatmap, last ${buckets.length} weeks`}
         aria-describedby={summaryId}
+        style={{ columnGap: `${GAP_PX}px`, rowGap: 0 }}
       >
-        <div
-          className="grid h-4 items-end text-[10px] leading-none text-muted-foreground"
-          style={{ gridTemplateColumns, columnGap: `${GAP_PX}px` }}
-          aria-hidden="true"
-        >
-          {labels.map((label, index) => (
-            <span
-              key={index}
-              className="overflow-visible whitespace-nowrap"
-            >
-              {label}
-            </span>
-          ))}
-        </div>
-        <div
-          className="grid"
-          style={{ gridTemplateColumns, columnGap: `${GAP_PX}px` }}
-        >
-          {buckets.map((bucket) => (
-            <HeatmapCell key={bucket.weekStart.getTime()} bucket={bucket} />
-          ))}
-        </div>
+        {buckets.map((bucket, index) => (
+          <div
+            key={bucket.weekStart.getTime()}
+            className="relative"
+            style={{ marginTop: `${LABEL_SPACE_PX}px` }}
+          >
+            {labels[index] && (
+              <span
+                aria-hidden="true"
+                className="absolute -top-[14px] left-0 text-[10px] leading-none text-muted-foreground whitespace-nowrap"
+              >
+                {labels[index]}
+              </span>
+            )}
+            <HeatmapCell bucket={bucket} />
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/client/src/components/visualization/WeeklyHeatmap/WeeklyHeatmapCard.tsx
+++ b/client/src/components/visualization/WeeklyHeatmap/WeeklyHeatmapCard.tsx
@@ -1,0 +1,53 @@
+import { useMemo } from "react";
+import { Loading } from "@/components/states/Loading";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { useActivities } from "@/data";
+import { HeatmapLegend } from "./HeatmapLegend";
+import { WeeklyHeatmap } from "./WeeklyHeatmap";
+import { buildWeeklyHeatmap } from "./weekly-heatmap-data";
+
+export function WeeklyHeatmapCard() {
+  const { data, isLoading } = useActivities();
+
+  const buckets = useMemo(
+    () => buildWeeklyHeatmap(data ?? [], { weeks: 52 }),
+    [data]
+  );
+
+  const hasActivities = (data?.length ?? 0) > 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Weekly Activity Heatmap</CardTitle>
+        <CardDescription>
+          Each cell is one week over the last 52 weeks · counts active
+          activities
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Loading />
+        ) : !hasActivities ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            No activities yet — log your first activity to start building your
+            weekly heatmap.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            <WeeklyHeatmap buckets={buckets} />
+            <div className="flex justify-end">
+              <HeatmapLegend />
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/components/visualization/WeeklyHeatmap/heatmap-colors.test.ts
+++ b/client/src/components/visualization/WeeklyHeatmap/heatmap-colors.test.ts
@@ -5,8 +5,12 @@ describe("levelStyle", () => {
   it("renders an empty week (level 0) as a hollow, transparent cell with a border ring", () => {
     const style = levelStyle(0);
     expect(style.backgroundColor).toBe("transparent");
-    // A visible outline is what makes empty weeks distinct from level 1.
-    expect(style.boxShadow).toMatch(/inset/);
+    // A visible border outline is what makes empty weeks distinct from level 1.
+    // It is deliberately a `border`, not an inline box-shadow: the cell's
+    // Tailwind focus-visible:ring-* is box-shadow based, so an inline box-shadow
+    // would override it and hide the keyboard focus ring on empty cells. The
+    // LevelStyle type (no `boxShadow` member) enforces this at compile time.
+    expect(style.border).toMatch(/var\(--color-border\)/);
   });
 
   it("fills active levels with the theme primary (no transparency)", () => {

--- a/client/src/components/visualization/WeeklyHeatmap/heatmap-colors.test.ts
+++ b/client/src/components/visualization/WeeklyHeatmap/heatmap-colors.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { HEATMAP_LEVELS, levelStyle } from "./heatmap-colors";
+
+describe("levelStyle", () => {
+  it("renders an empty week (level 0) as a hollow, transparent cell with a border ring", () => {
+    const style = levelStyle(0);
+    expect(style.backgroundColor).toBe("transparent");
+    // A visible outline is what makes empty weeks distinct from level 1.
+    expect(style.boxShadow).toMatch(/inset/);
+  });
+
+  it("fills active levels with the theme primary (no transparency)", () => {
+    for (const level of [1, 2, 3, 4] as const) {
+      const style = levelStyle(level);
+      expect(style.backgroundColor).not.toBe("transparent");
+      expect(style.backgroundColor).toContain("var(--color-primary)");
+    }
+  });
+
+  it("uses a raised floor so level 1 is clearly coloured, ramping up to solid primary", () => {
+    // Level 1 must be a substantial mix (raised floor), not near-background.
+    const one = String(levelStyle(1).backgroundColor);
+    const floor = Number(one.match(/(\d+)%/)?.[1]);
+    expect(floor).toBeGreaterThanOrEqual(40);
+
+    // Top of the ramp is the solid primary token.
+    expect(levelStyle(4).backgroundColor).toBe("var(--color-primary)");
+  });
+
+  it("increases intensity monotonically from level 1 to 4", () => {
+    const pct = (level: 1 | 2 | 3 | 4) =>
+      Number(String(levelStyle(level).backgroundColor).match(/(\d+)%/)?.[1] ?? 100);
+    expect(pct(1)).toBeLessThan(pct(2));
+    expect(pct(2)).toBeLessThan(pct(3));
+    expect(pct(3)).toBeLessThan(pct(4));
+  });
+
+  it("exposes all five levels in order for the legend", () => {
+    expect(HEATMAP_LEVELS).toEqual([0, 1, 2, 3, 4]);
+  });
+});

--- a/client/src/components/visualization/WeeklyHeatmap/heatmap-colors.ts
+++ b/client/src/components/visualization/WeeklyHeatmap/heatmap-colors.ts
@@ -1,23 +1,35 @@
+import type { CSSProperties } from "react";
 import type { HeatmapLevel } from "./weekly-heatmap-data";
 
+/** Inline style for a single heatmap cell at a given level. */
+export type LevelStyle = Pick<CSSProperties, "backgroundColor" | "boxShadow">;
+
+const mix = (pct: number) =>
+  `color-mix(in oklab, var(--color-primary) ${pct}%, var(--color-background))`;
+
 /**
- * Explicit 5-step shade ramp built from theme tokens (NOT opacity), so the
- * heatmap stays legible in both light and dark themes. Level 0 uses the muted
- * token to read clearly as "empty" and stay distinct from level 1.
+ * Explicit 5-step treatment (NOT opacity), so the heatmap stays legible in both
+ * light and dark themes and for colour-blind users.
  *
- * `color-mix` against `--color-background` keeps each step anchored to the
- * current theme's surface, so the ramp re-themes automatically.
+ * Empty weeks (level 0) render as a HOLLOW cell — transparent fill with a
+ * border ring — so they read clearly as "nothing logged" and stay obviously
+ * distinct from level 1. Active levels use a raised-floor primary ramp
+ * (level 1 starts at a substantial 42% mix, not near-background) climbing to
+ * the solid primary token, so even one active activity is unmistakable.
  */
-const LEVEL_BACKGROUND: Record<HeatmapLevel, string> = {
-  0: "var(--color-muted)",
-  1: "color-mix(in oklab, var(--color-primary) 28%, var(--color-background))",
-  2: "color-mix(in oklab, var(--color-primary) 50%, var(--color-background))",
-  3: "color-mix(in oklab, var(--color-primary) 72%, var(--color-background))",
-  4: "var(--color-primary)",
+const LEVEL_STYLES: Record<HeatmapLevel, LevelStyle> = {
+  0: {
+    backgroundColor: "transparent",
+    boxShadow: "inset 0 0 0 1.5px var(--color-border)",
+  },
+  1: { backgroundColor: mix(42) },
+  2: { backgroundColor: mix(60) },
+  3: { backgroundColor: mix(80) },
+  4: { backgroundColor: "var(--color-primary)" },
 };
 
-export function levelBackground(level: HeatmapLevel): string {
-  return LEVEL_BACKGROUND[level];
+export function levelStyle(level: HeatmapLevel): LevelStyle {
+  return LEVEL_STYLES[level];
 }
 
 export const HEATMAP_LEVELS: HeatmapLevel[] = [0, 1, 2, 3, 4];

--- a/client/src/components/visualization/WeeklyHeatmap/heatmap-colors.ts
+++ b/client/src/components/visualization/WeeklyHeatmap/heatmap-colors.ts
@@ -1,0 +1,23 @@
+import type { HeatmapLevel } from "./weekly-heatmap-data";
+
+/**
+ * Explicit 5-step shade ramp built from theme tokens (NOT opacity), so the
+ * heatmap stays legible in both light and dark themes. Level 0 uses the muted
+ * token to read clearly as "empty" and stay distinct from level 1.
+ *
+ * `color-mix` against `--color-background` keeps each step anchored to the
+ * current theme's surface, so the ramp re-themes automatically.
+ */
+const LEVEL_BACKGROUND: Record<HeatmapLevel, string> = {
+  0: "var(--color-muted)",
+  1: "color-mix(in oklab, var(--color-primary) 28%, var(--color-background))",
+  2: "color-mix(in oklab, var(--color-primary) 50%, var(--color-background))",
+  3: "color-mix(in oklab, var(--color-primary) 72%, var(--color-background))",
+  4: "var(--color-primary)",
+};
+
+export function levelBackground(level: HeatmapLevel): string {
+  return LEVEL_BACKGROUND[level];
+}
+
+export const HEATMAP_LEVELS: HeatmapLevel[] = [0, 1, 2, 3, 4];

--- a/client/src/components/visualization/WeeklyHeatmap/heatmap-colors.ts
+++ b/client/src/components/visualization/WeeklyHeatmap/heatmap-colors.ts
@@ -2,7 +2,7 @@ import type { CSSProperties } from "react";
 import type { HeatmapLevel } from "./weekly-heatmap-data";
 
 /** Inline style for a single heatmap cell at a given level. */
-export type LevelStyle = Pick<CSSProperties, "backgroundColor" | "boxShadow">;
+export type LevelStyle = Pick<CSSProperties, "backgroundColor" | "border">;
 
 const mix = (pct: number) =>
   `color-mix(in oklab, var(--color-primary) ${pct}%, var(--color-background))`;
@@ -13,14 +13,17 @@ const mix = (pct: number) =>
  *
  * Empty weeks (level 0) render as a HOLLOW cell — transparent fill with a
  * border ring — so they read clearly as "nothing logged" and stay obviously
- * distinct from level 1. Active levels use a raised-floor primary ramp
+ * distinct from level 1. The ring is a `border`, NOT an inline `box-shadow`:
+ * the cell's keyboard focus indicator is a Tailwind `focus-visible:ring-*`
+ * (also box-shadow based), and an inline box-shadow would override it, hiding
+ * the focus ring on empty cells. Active levels use a raised-floor primary ramp
  * (level 1 starts at a substantial 42% mix, not near-background) climbing to
  * the solid primary token, so even one active activity is unmistakable.
  */
 const LEVEL_STYLES: Record<HeatmapLevel, LevelStyle> = {
   0: {
     backgroundColor: "transparent",
-    boxShadow: "inset 0 0 0 1.5px var(--color-border)",
+    border: "1.5px solid var(--color-border)",
   },
   1: { backgroundColor: mix(42) },
   2: { backgroundColor: mix(60) },

--- a/client/src/components/visualization/WeeklyHeatmap/index.ts
+++ b/client/src/components/visualization/WeeklyHeatmap/index.ts
@@ -1,0 +1,11 @@
+export { WeeklyHeatmapCard } from "./WeeklyHeatmapCard";
+export { WeeklyHeatmap } from "./WeeklyHeatmap";
+export { HeatmapLegend } from "./HeatmapLegend";
+export {
+  buildWeeklyHeatmap,
+  getLevel,
+  getMonthLabels,
+  type HeatmapActivity,
+  type HeatmapLevel,
+  type WeeklyBucket,
+} from "./weekly-heatmap-data";

--- a/client/src/components/visualization/WeeklyHeatmap/weekly-heatmap-data.test.ts
+++ b/client/src/components/visualization/WeeklyHeatmap/weekly-heatmap-data.test.ts
@@ -1,0 +1,172 @@
+import {
+  addWeeks,
+  getISOWeek,
+  getISOWeekYear,
+  startOfWeek,
+  subWeeks,
+} from "date-fns";
+import { describe, expect, it } from "vitest";
+import {
+  buildWeeklyHeatmap,
+  getLevel,
+  getMonthLabels,
+  type HeatmapActivity,
+} from "./weekly-heatmap-data";
+
+/** Local-midday date avoids timezone edge flakiness. */
+function localDay(year: number, monthIndex: number, day: number): Date {
+  return new Date(year, monthIndex, day, 12, 0, 0, 0);
+}
+
+function activity(date: Date, active = true): HeatmapActivity {
+  return { date, active };
+}
+
+const MONDAY = { weekStartsOn: 1 } as const;
+
+describe("getLevel", () => {
+  it("buckets counts into 5 levels (0, 1-2, 3-4, 5-6, 7+)", () => {
+    expect(getLevel(0)).toBe(0);
+    expect(getLevel(1)).toBe(1);
+    expect(getLevel(2)).toBe(1);
+    expect(getLevel(3)).toBe(2);
+    expect(getLevel(4)).toBe(2);
+    expect(getLevel(5)).toBe(3);
+    expect(getLevel(6)).toBe(3);
+    expect(getLevel(7)).toBe(4);
+    expect(getLevel(99)).toBe(4);
+  });
+});
+
+describe("buildWeeklyHeatmap", () => {
+  const endDate = localDay(2024, 5, 15); // Sat Jun 15 2024
+
+  it("returns exactly `weeks` contiguous buckets ending at the week of endDate", () => {
+    const buckets = buildWeeklyHeatmap([], { endDate, weeks: 52 });
+    expect(buckets).toHaveLength(52);
+
+    const lastWeekStart = startOfWeek(endDate, MONDAY);
+    expect(buckets[51].weekStart.getTime()).toBe(lastWeekStart.getTime());
+    expect(buckets[0].weekStart.getTime()).toBe(
+      subWeeks(lastWeekStart, 51).getTime()
+    );
+
+    // Each bucket is exactly one week after the previous one.
+    for (let i = 1; i < buckets.length; i++) {
+      expect(buckets[i].weekStart.getTime()).toBe(
+        addWeeks(buckets[i - 1].weekStart, 1).getTime()
+      );
+    }
+  });
+
+  it("honors a custom `weeks` window length", () => {
+    expect(buildWeeklyHeatmap([], { endDate, weeks: 12 })).toHaveLength(12);
+  });
+
+  it("canonicalizes activities to their local Monday week and counts them", () => {
+    // Sun Jun 9 2024 belongs to the week starting Mon Jun 3 2024,
+    // while Mon Jun 10 2024 belongs to the latest week.
+    const activities = [
+      activity(localDay(2024, 5, 9)), // -> week of Jun 3
+      activity(localDay(2024, 5, 10)), // -> week of Jun 10
+      activity(localDay(2024, 5, 12)), // -> week of Jun 10
+      activity(localDay(2024, 5, 15)), // -> week of Jun 10
+    ];
+    const buckets = buildWeeklyHeatmap(activities, { endDate, weeks: 52 });
+
+    const latest = buckets[51];
+    expect(latest.count).toBe(3);
+    expect(latest.level).toBe(2); // 3 -> level 2
+
+    const prev = buckets[50];
+    expect(prev.weekStart.getTime()).toBe(
+      startOfWeek(localDay(2024, 5, 3), MONDAY).getTime()
+    );
+    expect(prev.count).toBe(1);
+    expect(prev.level).toBe(1);
+  });
+
+  it("keeps empty weeks present as count 0 / level 0 (no gaps)", () => {
+    const buckets = buildWeeklyHeatmap([activity(endDate)], {
+      endDate,
+      weeks: 52,
+    });
+    const empty = buckets.filter((b) => b.count === 0);
+    expect(empty).toHaveLength(51);
+    empty.forEach((b) => expect(b.level).toBe(0));
+  });
+
+  it("excludes inactive activities by default", () => {
+    const activities = [
+      activity(endDate, true),
+      activity(endDate, false),
+      activity(endDate, false),
+    ];
+    const buckets = buildWeeklyHeatmap(activities, { endDate, weeks: 52 });
+    expect(buckets[51].count).toBe(1);
+  });
+
+  it("includes inactive activities when includeInactive is true", () => {
+    const activities = [
+      activity(endDate, true),
+      activity(endDate, false),
+      activity(endDate, false),
+    ];
+    const buckets = buildWeeklyHeatmap(activities, {
+      endDate,
+      weeks: 52,
+      includeInactive: true,
+    });
+    expect(buckets[51].count).toBe(3);
+  });
+
+  it("drops activities outside the window", () => {
+    const old = activity(subWeeks(endDate, 60)); // older than 52 weeks
+    const future = activity(addWeeks(endDate, 3)); // after endDate's week
+    const buckets = buildWeeklyHeatmap([old, future], { endDate, weeks: 52 });
+    expect(buckets.every((b) => b.count === 0)).toBe(true);
+  });
+
+  it("derives ISO week 53 and previous ISO year at the Jan-1 boundary", () => {
+    // Fri Jan 1 2021 belongs to ISO week 53 of ISO year 2020.
+    const endOf2020Boundary = localDay(2021, 0, 1);
+    const buckets = buildWeeklyHeatmap([activity(endOf2020Boundary)], {
+      endDate: endOf2020Boundary,
+      weeks: 52,
+    });
+    const latest = buckets[51];
+
+    const expectedWeekStart = startOfWeek(endOf2020Boundary, MONDAY); // Mon Dec 28 2020
+    expect(latest.weekStart.getTime()).toBe(expectedWeekStart.getTime());
+    expect(latest.isoWeek).toBe(getISOWeek(expectedWeekStart));
+    expect(latest.isoWeek).toBe(53);
+    expect(latest.isoYear).toBe(getISOWeekYear(expectedWeekStart));
+    expect(latest.isoYear).toBe(2020);
+    expect(latest.count).toBe(1);
+  });
+});
+
+describe("getMonthLabels", () => {
+  it("labels the first column and every column where the month changes", () => {
+    const endDate = new Date(2024, 1, 5, 12); // Mon Feb 5 2024
+    const buckets = buildWeeklyHeatmap([], { endDate, weeks: 8 });
+    const labels = getMonthLabels(buckets);
+
+    expect(labels).toHaveLength(buckets.length);
+    expect(labels[0]).not.toBeNull(); // first column always labeled
+
+    // A non-null label appears only when its month differs from the previous bucket.
+    for (let i = 1; i < buckets.length; i++) {
+      const changed =
+        buckets[i].weekStart.getMonth() !== buckets[i - 1].weekStart.getMonth();
+      if (changed) {
+        expect(labels[i]).not.toBeNull();
+      } else {
+        expect(labels[i]).toBeNull();
+      }
+    }
+
+    // At least one boundary exists across an 8-week window.
+    expect(labels.filter((l) => l !== null).length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/client/src/components/visualization/WeeklyHeatmap/weekly-heatmap-data.ts
+++ b/client/src/components/visualization/WeeklyHeatmap/weekly-heatmap-data.ts
@@ -1,0 +1,110 @@
+import {
+  addWeeks,
+  endOfWeek,
+  format,
+  getISOWeek,
+  getISOWeekYear,
+  startOfWeek,
+} from "date-fns";
+
+/** Minimal shape needed to aggregate activities into weekly buckets. */
+export type HeatmapActivity = {
+  date: Date;
+  active: boolean;
+};
+
+export type HeatmapLevel = 0 | 1 | 2 | 3 | 4;
+
+export type WeeklyBucket = {
+  /** Local Monday that starts the week (primary identity). */
+  weekStart: Date;
+  /** Local Sunday that ends the week (display only). */
+  weekEnd: Date;
+  /** ISO week number, for display only. */
+  isoWeek: number;
+  /** ISO week-numbering year, for display only. */
+  isoYear: number;
+  count: number;
+  level: HeatmapLevel;
+};
+
+export type BuildWeeklyHeatmapOptions = {
+  endDate?: Date;
+  weeks?: number;
+  includeInactive?: boolean;
+};
+
+/** ISO 8601 weeks start on Monday. */
+const WEEK_OPTIONS = { weekStartsOn: 1 } as const;
+
+/** Bucket an activity count into one of five shade levels. */
+export function getLevel(count: number): HeatmapLevel {
+  if (count <= 0) return 0;
+  if (count <= 2) return 1;
+  if (count <= 4) return 2;
+  if (count <= 6) return 3;
+  return 4;
+}
+
+/** Stable per-week key derived from the local Monday week-start. */
+function weekKey(date: Date): string {
+  return format(startOfWeek(date, WEEK_OPTIONS), "yyyy-MM-dd");
+}
+
+/**
+ * Aggregate activities into exactly `weeks` contiguous weekly buckets ending at
+ * the week containing `endDate`. Empty weeks are present with count 0 / level 0.
+ *
+ * Weeks are keyed by their LOCAL Monday week-start; ISO week/year and week-end
+ * are derived for DISPLAY only.
+ */
+export function buildWeeklyHeatmap(
+  activities: ReadonlyArray<HeatmapActivity>,
+  options: BuildWeeklyHeatmapOptions = {}
+): WeeklyBucket[] {
+  const { endDate = new Date(), weeks = 52, includeInactive = false } = options;
+
+  const lastWeekStart = startOfWeek(endDate, WEEK_OPTIONS);
+
+  const counts = new Map<string, number>();
+  for (const activity of activities) {
+    if (!includeInactive && !activity.active) continue;
+    const key = weekKey(activity.date);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  const buckets: WeeklyBucket[] = [];
+  for (let i = weeks - 1; i >= 0; i--) {
+    const weekStart = addWeeks(lastWeekStart, -i);
+    const key = format(weekStart, "yyyy-MM-dd");
+    const count = counts.get(key) ?? 0;
+    buckets.push({
+      weekStart,
+      weekEnd: endOfWeek(weekStart, WEEK_OPTIONS),
+      isoWeek: getISOWeek(weekStart),
+      isoYear: getISOWeekYear(weekStart),
+      count,
+      level: getLevel(count),
+    });
+  }
+
+  return buckets;
+}
+
+/**
+ * Returns a label array aligned to `buckets`: a month short-name at the first
+ * column and at every column whose month differs from the previous week,
+ * `null` otherwise.
+ */
+export function getMonthLabels(
+  buckets: ReadonlyArray<WeeklyBucket>
+): (string | null)[] {
+  return buckets.map((bucket, index) => {
+    if (index === 0) return format(bucket.weekStart, "MMM");
+    const prevMonth = buckets[index - 1].weekStart.getMonth();
+    if (bucket.weekStart.getMonth() !== prevMonth) {
+      return format(bucket.weekStart, "MMM");
+    }
+    return null;
+  });
+}

--- a/client/src/data/queryOptions.ts
+++ b/client/src/data/queryOptions.ts
@@ -1,4 +1,5 @@
 import { queryOptions } from "@tanstack/react-query";
+import { parseISO } from "date-fns";
 import {
   activitiesApiPath,
   categoriesApiPath,
@@ -42,7 +43,10 @@ const fetchActivities = async (
 
   return activityRecordsResponse.map((activityRecord) => ({
     ...activityRecord,
-    date: new Date(activityRecord.date),
+    // Parse date-only strings (yyyy-MM-dd) as LOCAL dates. `new Date(str)`
+    // would treat them as UTC midnight, shifting them to the previous day in
+    // timezones west of UTC and bucketing them into the wrong local week.
+    date: parseISO(activityRecord.date),
   }));
 };
 

--- a/client/src/pages/Welcome.tsx
+++ b/client/src/pages/Welcome.tsx
@@ -8,6 +8,7 @@ import { AddWithDetailsDialog } from "../components/forms/AddActivityForm/AddWit
 import { IntensityBadge } from "../components/IntensityBadge";
 import { OnboardingCard } from "../components/OnboardingCard";
 import { Loading } from "../components/states/Loading";
+import { WeeklyHeatmapCard } from "../components/visualization/WeeklyHeatmap";
 import {
   Card,
   CardAction,
@@ -171,6 +172,9 @@ export const Welcome = () => {
           );
         })}
       </div>
+
+      {/* Weekly Activity Heatmap */}
+      <WeeklyHeatmapCard />
 
       {/* Log Activity + Recent Activities */}
       <div className="grid gap-4 lg:grid-cols-2">

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -134,6 +134,13 @@ export default defineConfig(async (): Promise<UserConfig> => {
     test: {
       projects: [
         {
+          test: {
+            name: "unit",
+            environment: "node",
+            include: ["src/**/*.test.ts"],
+          },
+        },
+        {
           extends: true,
           plugins: [
             // The plugin will run tests for the stories defined in your Storybook config


### PR DESCRIPTION
## What

Adds a GitHub‑contribution‑style **Weekly Activity Heatmap** to the dashboard: a single horizontal strip of the last **52 weeks**, each cell shaded by how many activities were logged that week. Lives in a `Card` titled *“Weekly Activity Heatmap”* between the stat cards and the Log/Recent grid, with month labels above the strip and a *Less → More* legend bottom‑right. On narrow screens the strip **wraps** onto further rows (no horizontal scroll); month markers stay aligned to each month's first cell.

## Preview

`Visualization/WeeklyHeatmap` story (seeded deterministic data). The strip is a single continuous row on wide containers and **wraps** on narrow ones — no horizontal scroll. Month markers stay correctly positioned above each month's first cell wherever it wraps.

**Light** (card width — wraps to two rows)

![Weekly Activity Heatmap — light](https://raw.githubusercontent.com/sjwilczynski/Activity-tracker/heatmap-assets/heatmap-light.png)

**Dark**

![Weekly Activity Heatmap — dark](https://raw.githubusercontent.com/sjwilczynski/Activity-tracker/heatmap-assets/heatmap-dark.png)

**Phone width (~380px)** — empty weeks are hollow, active weeks filled

![Weekly Activity Heatmap — phone](https://raw.githubusercontent.com/sjwilczynski/Activity-tracker/heatmap-assets/heatmap-phone.png)

## Why

The existing dashboard shows point‑in‑time counts (Last 7/30 days) but no sense of consistency over time. A weekly heatmap surfaces streaks, gaps, and long‑term trends at a glance.

## How

- **Metric (decided):** active activity **count** per week, bucketed into 5 levels — `0→L0`, `1–2→L1`, `3–4→L2`, `5–6→L3`, `7+→L4`. Inactive activities are excluded (consistent with the Last 7/30‑day cards).
- **Week identity:** each activity is canonicalized to its **local Monday week‑start** via `startOfWeek(date, { weekStartsOn: 1 })`. ISO week / ISO year / week‑end / month label are derived for **display only** (so the Jan‑1 / ISO‑week‑53 boundary is handled correctly).
- **Pure core:** `buildWeeklyHeatmap(activities, { endDate, weeks = 52, includeInactive = false })` returns exactly `weeks` contiguous buckets; empty weeks are present as level 0 (no gaps). It’s fully unit‑tested and decoupled from React.
- **Color:** an explicit 5‑step treatment (not opacity). Empty weeks (level 0) render as a **hollow** cell — transparent fill + `var(--color-border)` ring — so they read clearly as "nothing logged" and stay distinct from level 1. Active levels use a **raised‑floor** primary ramp (`color-mix(in oklab, var(--color-primary) 42/60/80/100%, var(--color-background))`) so even one activity is unmistakable. Re‑themes automatically; legible in **light and dark**.

## Placement decision

Rendered as a full‑width block in the main dashboard stack, inserted **between** the 4‑up stat‑cards grid and the *Log Activity + Recent Activities* grid. It is **not** shown in the onboarding (empty‑categories) branch.

## Accessibility

- Each cell is a keyboard‑focusable `<button>` with a useful label, e.g. *“Week of Jun 10, 2024: 6 activities”*.
- Tooltip (reused/completed `components/ui/tooltip` shadcn primitive) shows on **hover and keyboard focus** — no reliance on the native `title` attribute.
- Visible *Less → More* legend plus an `sr-only` summary of the whole heatmap (totals + busiest week).
- Color never conveys magnitude alone (count is in every label/tooltip).

States: **loading** reuses the existing `Loading` component; **empty** shows a friendly message inside the card.

## Coupled bug fix (found in self‑review)

`queryOptions.fetchActivities` parsed date‑only strings (`"2024-06-10"`) with `new Date(...)`, which treats them as **UTC midnight** and shifts them to the previous day in timezones west of UTC — bucketing Monday activities into the previous local week. Switched to `parseISO` (parses date‑only as local). No behavior change in UTC/east‑of‑UTC; fixes the off‑by‑one‑week west of UTC. Verified via a `TZ=America/New_York` repro.

## Tests

- **Unit (plain Vitest, node project):** `weekly-heatmap-data.test.ts` — 52‑week window, level bucketing, active‑only filtering, empty weeks as L0, out‑of‑window drop, ISO‑week‑53 / previous‑ISO‑year boundary, month‑label derivation.
- **Storybook play function:** `WeeklyHeatmap.stories.tsx` with seeded deterministic data — asserts 52 cells render, a known busy week has the expected level + aria‑label, and the legend is present.
- Existing `Welcome.stories.tsx` (and the rest of the suite) unchanged and green.

Verification (Node 22): `bun run lint` ✓, `cd client && bunx tsc --noEmit` ✓, `cd client && bunx vitest run` → **87 passed (14 files)**. Rendered heatmap visually verified in Storybook in both light and dark themes.

> Note: added a small node `unit` project to `client/vite.config.ts` so plain `*.test.ts` files run under `bunx vitest run` (the existing single project only runs Storybook stories in the browser).

## Review feedback addressed

**Small-screen layout + colour contrast (from review discussion):** explored layout × colour variants in a throwaway Storybook prototype and folded in the winners — **continuous wrap** (replacing horizontal scroll) and **hollow empty weeks + raised-floor ramp** (replacing the muted level-0 that was too close to level 1). Prototype deleted; the colour treatment is covered by a new `heatmap-colors.test.ts` and the story asserts empty weeks render transparent.


- **`outline-hidden` instead of `outline-none`** on cells, so the forced‑colors focus fallback is preserved while the custom `focus-visible` ring still applies.
- **`aria-describedby`** now links the `role="group"` strip to its `sr-only` summary, using a `useId()`‑generated id so multiple instances never collide. Story asserts the association.
- Empty‑state check intentionally keyed off whether the user has *any* activity (brand‑new‑user copy: “log your first activity”), not off bucket counts — a user with only inactive/old activities correctly renders an all‑level‑0 strip rather than the onboarding message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a weekly activity heatmap to the dashboard, including a card view, color legend, and detailed hover tooltips.
  * The heatmap now shows 52 weeks of activity with clear month markers and accessible summaries.
  * Added supporting Storybook coverage for the new visualization.

* **Bug Fixes**
  * Improved date handling so day-only activity dates are displayed in the correct local week.
  * Refined heatmap styling so inactive weeks render clearly and active weeks use distinct intensity levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->