### PR TITLE
feat(draft): optimistic updates for activity edit & delete

### DIFF
--- a/client/.storybook/preview.ts
+++ b/client/.storybook/preview.ts
@@ -9,6 +9,12 @@ import { REFERENCE_DATE } from "../src/mocks/data/activities";
 import { withAllProviders, withRouter } from "../src/mocks/decorators";
 import { handlers, resetActivities, resetCategories } from "../src/mocks/handlers";
 import { testContext } from "../src/mocks/testContext";
+import {
+  removeActivityById,
+  replaceActivityById,
+  runOptimisticActivityMutation,
+} from "../src/data/optimisticActivities";
+import type { ActivityRecordServer } from "../src/data/types";
 
 // Disable Chart.js animations in Storybook to fix rendering issues
 // in the constrained iframe environment
@@ -38,6 +44,10 @@ const mockAction = async ({ request }: { request: Request }) => {
   const formData = await request.formData();
   const intent = formData.get("intent");
   const token = "mock-token-12345";
+  // Mirrors the real route action's optimistic updates (see
+  // app/routes/activity-list.tsx). The QueryClient is published by the
+  // withAllProviders decorator via testContext.
+  const queryClient = testContext.getQueryClient();
 
   try {
     let response: Response | undefined;
@@ -57,22 +67,40 @@ const mockAction = async ({ request }: { request: Request }) => {
     if (intent === "edit") {
       const id = formData.get("id") as string;
       const record = formData.get("record") as string;
-      response = await fetch(`/api/activities/${id}`, {
-        method: "PUT",
-        headers: {
-          "x-auth-token": token,
-          "Content-Type": "application/json",
-        },
-        body: record,
-      });
+      const performEdit = () =>
+        fetch(`/api/activities/${id}`, {
+          method: "PUT",
+          headers: {
+            "x-auth-token": token,
+            "Content-Type": "application/json",
+          },
+          body: record,
+        });
+      if (queryClient) {
+        return await runOptimisticActivityMutation(
+          queryClient,
+          replaceActivityById(id, JSON.parse(record) as ActivityRecordServer),
+          performEdit
+        );
+      }
+      response = await performEdit();
     }
 
     if (intent === "delete") {
       const id = formData.get("id") as string;
-      response = await fetch(`/api/activities/${id}`, {
-        method: "DELETE",
-        headers: { "x-auth-token": token },
-      });
+      const performDelete = () =>
+        fetch(`/api/activities/${id}`, {
+          method: "DELETE",
+          headers: { "x-auth-token": token },
+        });
+      if (queryClient) {
+        return await runOptimisticActivityMutation(
+          queryClient,
+          removeActivityById(id),
+          performDelete
+        );
+      }
+      response = await performDelete();
     }
 
     if (intent === "delete-all") {

--- a/client/src/app/routes/activity-list.tsx
+++ b/client/src/app/routes/activity-list.tsx
@@ -1,9 +1,15 @@
 import { RouteErrorBoundary } from "../../components/states/RouteErrorBoundary";
 import { apiFetch } from "../../data/apiClient";
 import {
+  removeActivityById,
+  replaceActivityById,
+  runOptimisticActivityMutation,
+} from "../../data/optimisticActivities";
+import {
   activitiesQueryOptions,
   categoriesQueryOptions,
 } from "../../data/queryOptions";
+import type { ActivityRecordServer } from "../../data/types";
 import { ActivityList as ActivityListPage } from "../../pages/ActivityList";
 import { getLoadContext } from "../root";
 import type { Route } from "./+types/activity-list";
@@ -28,30 +34,35 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
 
   if (intent === "edit") {
     const id = formData.get("id") as string;
-    const record = JSON.parse(formData.get("record") as string);
+    const record = JSON.parse(
+      formData.get("record") as string
+    ) as ActivityRecordServer;
 
-    const response = await apiFetch(getAuthToken, `/api/activities/${id}`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(record),
-      allowNotOk: true,
-    });
+    return runOptimisticActivityMutation(
+      queryClient,
+      replaceActivityById(id, record),
+      () =>
+        apiFetch(getAuthToken, `/api/activities/${id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(record),
+          allowNotOk: true,
+        })
+    );
+  }
 
-    if (!response.ok) {
-      return { error: `HTTP error! status: ${response.status}` };
-    }
-  } else if (intent === "delete") {
+  if (intent === "delete") {
     const id = formData.get("id") as string;
 
-    const response = await apiFetch(getAuthToken, `/api/activities/${id}`, {
-      method: "DELETE",
-      allowNotOk: true,
-    });
+    return runOptimisticActivityMutation(queryClient, removeActivityById(id), () =>
+      apiFetch(getAuthToken, `/api/activities/${id}`, {
+        method: "DELETE",
+        allowNotOk: true,
+      })
+    );
+  }
 
-    if (!response.ok) {
-      return { error: `HTTP error! status: ${response.status}` };
-    }
-  } else if (intent === "delete-all") {
+  if (intent === "delete-all") {
     const response = await apiFetch(getAuthToken, "/api/activities", {
       method: "DELETE",
       allowNotOk: true,
@@ -77,19 +88,12 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
     return { error: "Unknown intent" };
   }
 
-  const invalidations = [
+  await Promise.all([
     queryClient.invalidateQueries({ queryKey: ["activities"] }),
     queryClient.invalidateQueries({ queryKey: ["activitiesWithLimit"] }),
-  ];
-
-  if (intent === "import" || intent === "delete-all") {
-    invalidations.push(
-      queryClient.invalidateQueries({ queryKey: ["categories"] }),
-      queryClient.invalidateQueries({ queryKey: ["preferences"] })
-    );
-  }
-
-  await Promise.all(invalidations);
+    queryClient.invalidateQueries({ queryKey: ["categories"] }),
+    queryClient.invalidateQueries({ queryKey: ["preferences"] }),
+  ]);
 
   return { ok: true };
 }

--- a/client/src/data/optimisticActivities.ts
+++ b/client/src/data/optimisticActivities.ts
@@ -1,0 +1,124 @@
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
+import {
+  getActivitiesQueryId,
+  getActivitiesQueryIdWithLimit,
+} from "./react-query-config/query-constants";
+import type { ActivityRecordServer, ActivityRecordWithId } from "./types";
+
+type ActivityList = ActivityRecordWithId[];
+
+/** Pure transform applied to every cached activity list. */
+type ActivityUpdater = (records: ActivityList) => ActivityList;
+
+/**
+ * Snapshot of the activity caches taken before an optimistic update so it can
+ * be restored if the server request fails.
+ */
+type ActivitiesSnapshot = {
+  activities: ActivityList | undefined;
+  activitiesWithLimit: [QueryKey, ActivityList | undefined][];
+};
+
+/**
+ * Optimistically apply `update` to the cached activity lists — both the full
+ * `["activities"]` list and every `["activitiesWithLimit", limit]` variant —
+ * and return a snapshot for rollback. In-flight refetches are cancelled first
+ * so they cannot clobber the optimistic data (mirrors the `onMutate` step of
+ * `useUpdatePreferences`).
+ */
+async function applyOptimisticActivityUpdate(
+  queryClient: QueryClient,
+  update: ActivityUpdater
+): Promise<ActivitiesSnapshot> {
+  await Promise.all([
+    queryClient.cancelQueries({ queryKey: getActivitiesQueryId }),
+    queryClient.cancelQueries({ queryKey: getActivitiesQueryIdWithLimit }),
+  ]);
+
+  const snapshot: ActivitiesSnapshot = {
+    activities: queryClient.getQueryData<ActivityList>(getActivitiesQueryId),
+    activitiesWithLimit: queryClient.getQueriesData<ActivityList>({
+      queryKey: getActivitiesQueryIdWithLimit,
+    }),
+  };
+
+  const apply = (records: ActivityList | undefined) =>
+    records ? update(records) : records;
+
+  queryClient.setQueryData<ActivityList>(getActivitiesQueryId, apply);
+  queryClient.setQueriesData<ActivityList>(
+    { queryKey: getActivitiesQueryIdWithLimit },
+    apply
+  );
+
+  return snapshot;
+}
+
+/** Restore the activity caches captured by {@link applyOptimisticActivityUpdate}. */
+function rollbackActivities(
+  queryClient: QueryClient,
+  snapshot: ActivitiesSnapshot
+): void {
+  queryClient.setQueryData(getActivitiesQueryId, snapshot.activities);
+  for (const [queryKey, data] of snapshot.activitiesWithLimit) {
+    queryClient.setQueryData(queryKey, data);
+  }
+}
+
+/**
+ * Run an activity mutation with optimistic UI: apply `update` to the caches,
+ * perform the request, roll back on failure, and always invalidate so the
+ * server stays the source of truth (the `onMutate`/`onError`/`onSettled`
+ * lifecycle, adapted for react-router actions). Returns the route action's
+ * `{ ok }`/`{ error }` shape; rethrows network errors after rolling back.
+ */
+export async function runOptimisticActivityMutation(
+  queryClient: QueryClient,
+  update: ActivityUpdater,
+  performRequest: () => Promise<Response>
+): Promise<{ ok: true } | { error: string }> {
+  const snapshot = await applyOptimisticActivityUpdate(queryClient, update);
+
+  try {
+    const response = await performRequest();
+    if (!response.ok) {
+      rollbackActivities(queryClient, snapshot);
+      return { error: `HTTP error! status: ${response.status}` };
+    }
+    return { ok: true };
+  } catch (error) {
+    rollbackActivities(queryClient, snapshot);
+    throw error;
+  } finally {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: getActivitiesQueryId }),
+      queryClient.invalidateQueries({ queryKey: getActivitiesQueryIdWithLimit }),
+    ]);
+  }
+}
+
+/** Updater that removes the activity with the given id from a list. */
+export const removeActivityById =
+  (id: string): ActivityUpdater =>
+  (records) =>
+    records.filter((record) => record.id !== id);
+
+/**
+ * Updater that replaces the activity with the given id. The edit payload is an
+ * {@link ActivityRecordServer} (string date, no `id`/`active`), so we convert
+ * the date and carry over the existing `id` and `active` flag — the latter is
+ * reconciled by the post-success invalidation.
+ */
+export const replaceActivityById =
+  (id: string, record: ActivityRecordServer): ActivityUpdater =>
+  (records) =>
+    records.map((existing) =>
+      existing.id === id
+        ? {
+            ...record,
+            date: new Date(record.date),
+            id: existing.id,
+            active: existing.active,
+          }
+        : existing
+    );

--- a/client/src/pages/ActivityList.stories.tsx
+++ b/client/src/pages/ActivityList.stories.tsx
@@ -1,10 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { delay, http, HttpResponse } from "msw";
 import { expect, screen, userEvent, waitFor, within } from "storybook/test";
+import type { ActivityRecordServer } from "../data";
 import {
   darkPreferencesHandler,
   handlers as defaultHandlers,
 } from "../mocks/handlers";
+import { getActivities, setActivities } from "../mocks/handlers/activities";
 import { ActivityList } from "./ActivityList";
 
 const meta: Meta<typeof ActivityList> = {
@@ -14,6 +16,48 @@ const meta: Meta<typeof ActivityList> = {
 
 export default meta;
 type Story = StoryObj<typeof ActivityList>;
+
+/**
+ * Builds an activities-by-id handler that suspends until `gate.release()` is
+ * called, letting a play function assert the optimistic UI while the server
+ * request is still "in flight". `gate.completed` flips to true once the
+ * response has been produced, so a success assertion can prove the optimistic
+ * state survived the full round-trip (and was not rolled back) rather than only
+ * the optimistic phase. `finalize` mutates the mock server state so the
+ * post-settle refetch stays consistent with the optimistic change (skipped for
+ * error responses). The flags reset on each request so the gate is safe to
+ * reuse across runs/retries.
+ */
+function gatedActivityHandler(
+  method: "put" | "delete",
+  status: number,
+  finalize?: (id: string, request: Request) => Promise<void> | void
+) {
+  const gate: {
+    release?: () => void;
+    completed: boolean;
+    reset: () => void;
+  } = {
+    completed: false,
+    reset: () => {
+      gate.release = undefined;
+      gate.completed = false;
+    },
+  };
+  const handler = http[method]("*/api/activities/:id", async ({
+    params,
+    request,
+  }) => {
+    gate.completed = false;
+    await new Promise<void>((resolve) => {
+      gate.release = resolve;
+    });
+    await finalize?.(params.id as string, request);
+    gate.completed = true;
+    return new HttpResponse(null, { status });
+  });
+  return { handler, gate };
+}
 
 export const Default: Story = {
   play: async ({ canvasElement, step }) => {
@@ -224,6 +268,148 @@ export const DeleteRowInteraction: Story = {
       },
       { timeout: 5000 }
     );
+  },
+};
+
+// The server response is suspended via the gate so these assertions can only
+// pass if the UI updates optimistically (before the round-trip completes).
+const deleteSuccessGate = gatedActivityHandler("delete", 204, (id) => {
+  setActivities(getActivities().filter((activity) => activity.id !== id));
+});
+
+export const DeleteOptimisticUpdate: Story = {
+  parameters: {
+    msw: { handlers: [deleteSuccessGate.handler, ...defaultHandlers] },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await canvas.findByText("All Activities");
+    expect(canvas.getByText(/1–10 of 30/)).toBeInTheDocument();
+    deleteSuccessGate.gate.reset();
+
+    const deleteButtons = canvas.getAllByRole("button", { name: /^delete$/i });
+    await userEvent.click(deleteButtons[0]);
+
+    // Wait until the server request is in flight (and suspended by the gate),
+    // then assert the row is already gone — i.e. removed optimistically.
+    await waitFor(() => {
+      expect(deleteSuccessGate.gate.release).toBeDefined();
+    });
+    await waitFor(() => {
+      expect(canvas.getByText(/1–10 of 29/)).toBeInTheDocument();
+    });
+
+    // Let the server finish and wait for the response to be produced; the
+    // optimistic delete is then confirmed (not rolled back) and stays applied
+    // through the post-settle refetch.
+    deleteSuccessGate.gate.release?.();
+    await waitFor(() => {
+      expect(deleteSuccessGate.gate.completed).toBe(true);
+    });
+    await waitFor(() => {
+      expect(canvas.getByText(/1–10 of 29/)).toBeInTheDocument();
+    });
+  },
+};
+
+const deleteErrorGate = gatedActivityHandler("delete", 500);
+
+export const DeleteOptimisticRollback: Story = {
+  parameters: {
+    msw: { handlers: [deleteErrorGate.handler, ...defaultHandlers] },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await canvas.findByText("All Activities");
+    expect(canvas.getByText(/1–10 of 30/)).toBeInTheDocument();
+    deleteErrorGate.gate.reset();
+
+    const deleteButtons = canvas.getAllByRole("button", { name: /^delete$/i });
+    await userEvent.click(deleteButtons[0]);
+
+    // Optimistically removed while the (suspended) server request is in flight.
+    await waitFor(() => {
+      expect(deleteErrorGate.gate.release).toBeDefined();
+    });
+    await waitFor(() => {
+      expect(canvas.getByText(/1–10 of 29/)).toBeInTheDocument();
+    });
+
+    // Server fails → the row is rolled back into the list.
+    deleteErrorGate.gate.release?.();
+    await waitFor(() => {
+      expect(canvas.getByText(/1–10 of 30/)).toBeInTheDocument();
+    });
+  },
+};
+
+const editSuccessGate = gatedActivityHandler("put", 204, async (id, request) => {
+  const update = (await request.json()) as ActivityRecordServer;
+  setActivities(
+    getActivities().map((activity) =>
+      activity.id === id ? { ...activity, ...update } : activity
+    )
+  );
+});
+
+export const EditOptimisticUpdate: Story = {
+  parameters: {
+    msw: { handlers: [editSuccessGate.handler, ...defaultHandlers] },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await canvas.findByText("All Activities");
+    editSuccessGate.gate.reset();
+
+    await step("Open edit dialog and switch Running → Cycling", async () => {
+      const rows = canvas.getAllByTestId("activity-row");
+      expect(within(rows[0]).getByText("Running")).toBeInTheDocument();
+
+      const editButtons = canvas.getAllByRole("button", { name: /edit/i });
+      await userEvent.click(editButtons[0]);
+
+      await screen.findByRole("button", { name: /save changes/i });
+
+      await userEvent.click(
+        screen.getByRole("combobox", { name: /activity name/i })
+      );
+      await screen.findByText("Sports");
+      await userEvent.click(screen.getByRole("option", { name: /cycling/i }));
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /save changes/i })
+      );
+    });
+
+    await step("Row reflects the edit before the server responds", async () => {
+      await waitFor(() => {
+        expect(editSuccessGate.gate.release).toBeDefined();
+      });
+      await waitFor(() => {
+        const rows = canvas.getAllByTestId("activity-row");
+        expect(within(rows[0]).getByText("Cycling")).toBeInTheDocument();
+      });
+    });
+
+    await step("Release the server and confirm the edit settles", async () => {
+      editSuccessGate.gate.release?.();
+
+      await waitFor(() => {
+        expect(editSuccessGate.gate.completed).toBe(true);
+      });
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("heading", { level: 2, name: /edit activity/i })
+        ).not.toBeInTheDocument();
+      });
+      await waitFor(() => {
+        const rows = canvas.getAllByTestId("activity-row");
+        expect(within(rows[0]).getByText("Cycling")).toBeInTheDocument();
+      });
+    });
   },
 };
 


### PR DESCRIPTION
> ⚠️ **Exploratory spike — not proposed for merge as-is.** This is the lowest-ranked, most speculative item. I'm opening it to force a decision, and I want to lead with the honest doubts rather than sell the diff.

## TL;DR — read this before the code

I built working optimistic edit/delete, all tests pass — **and I don't think we should merge it in this shape.** Two questions matter more than the implementation:

1. **Is optimism even worth it here?** Edit/delete already have decent pending UX. `RowInReadMode` animates deletes (`isDeleting` → `opacity-0 scale-95`); edit closes the dialog then refetches. We're adding real complexity to shave ~100–300ms of perceived latency off operations that aren't currently painful. That's polish, not a fix. **A perfectly valid outcome of this PR is "no thanks, just tidy the existing pending states."**
2. **If we do want it, it's in the wrong layer.** I put optimism in the react-router **route action**. Almost all the complexity below is a *symptom of that choice*, not of optimism itself.

## Why the route-action approach fights us

- **Hand-rolled mutation lifecycle.** An action has no `onMutate`/`onError`/`onSettled`, so `runOptimisticActivityMutation` re-implements cancel → snapshot → rollback → settle by hand — i.e. it rebuilds what `useMutation` gives for free.
- **The Storybook duplication is the real smell.** Storybook runs a `mockAction`, **not** the real `clientAction`. To make optimism observable in tests I had to route it through a shared helper *and* wire that helper into `.storybook/preview.ts`. So the tests prove *a parallel mock* is optimistic — not that production is. That's a weak guarantee and a maintenance trap.
- **It introduces a UX regression.** Optimistic delete unmounts the row (filtered from cache), so the per-row delete **error toast** (owned by the row's fetcher) never fires on a failed delete — the row just silently reappears. Edit keeps the row mounted, so its toast still works. This asymmetry is a direct consequence of doing cache surgery in the action.

These are not three independent bugs to patch. They're one wrong abstraction.

## The alternative I'd actually back: approach (B), mutation hooks

`useEditActivity` / `useDeleteActivity` built on `useMutation`, called from the table instead of the form action:
- deletes the hand-rolled lifecycle (real `onMutate`/`onError`/`onSettled`),
- removes the `preview.ts` mock duplication — **tests exercise the real hook**, so they'd actually prove production behavior,
- surfaces errors naturally, fixing the lost delete toast.

The cost is touching the table components and changing how rows submit. For a *draft* I called that too much surface area — but if we're keeping optimism at all, that's the version worth building, and this PR's "more surface area" tradeoff is the wrong call.

## So what is this PR good for?

A **spike** that proves the behavior works and surfaces the real cost. I'd treat the decision as: **(a)** drop optimism and just polish existing pending states, **(b)** redo as hooks (approach B), or **(c)** accept these tradeoffs deliberately. My vote is (a) or (b), not merging this as the foundation.

---

## Reference: what's actually in the diff

Stacked on **#1170** (`sjwilczynski-scope-query-key-harden-errors-apiclient`); the PR base is that branch, so the diff is just this one commit. **Merge #1170 first.** Builds on its `apiFetch` wrapper and scoped `["activitiesWithLimit", limit]` key.

- `client/src/data/optimisticActivities.ts` (new) — shared cancel/snapshot/rollback/invalidate helper, mirroring `useUpdatePreferences`. Updates both `["activities"]` and `["activitiesWithLimit", limit]`.
- `client/src/app/routes/activity-list.tsx` — edit/delete branches call the helper; `delete-all`/`import` untouched.
- `client/.storybook/preview.ts` — `mockAction` calls the same helper (see smell above).
- `client/src/pages/ActivityList.stories.tsx` — 3 gated stories: optimistic apply, settle, and rollback. A gate suspends the MSW response so the optimistic phase is observable, plus a `completed` flag so success assertions prove the change survives the full round-trip.

**Checks:** `tsc --noEmit` ✓, `lint --max-warnings=0` ✓, full client suite 74/74 ✓.

## Open questions for the reviewer (please weigh in)

1. **Do we want optimism here at all**, or is polishing the existing pending/animation states the better use of time?
2. If yes — **approach B (hooks)** to kill the action/mock duplication and fix the lost delete toast? Worth the table churn?
3. **Lost delete-error toast on rollback** — acceptable interim, or a blocker?
4. **Concurrent mutations** — each snapshots/restores the whole list, so overlapping edits/deletes can transiently clobber each other before invalidation reconciles. Out of scope here; serialize or track per-record patches before any real hardening.
5. **`active` carry-over** — `replaceActivityById` keeps the existing `active` flag optimistically and lets the refetch reconcile. Fine, or derive client-side?