### PR TITLE
Rank closest activity match first in the activity picker

### DIFF
--- a/client/src/components/forms/adapters/CategoryAutocomplete.tsx
+++ b/client/src/components/forms/adapters/CategoryAutocomplete.tsx
@@ -1,4 +1,5 @@
 import { CheckIcon, ChevronsUpDownIcon } from "lucide-react";
+import { useCommandState } from "cmdk";
 import { useEffect, useId, useRef, useState } from "react";
 import type { CategoryOption } from "../../../data";
 import { useAvailableCategories } from "../../../data";
@@ -25,6 +26,69 @@ type CategoryAutocompleteProps = {
   hideLabel?: boolean;
 };
 
+/**
+ * Renders the selectable activity options inside a {@link Command}.
+ *
+ * While the user is searching we render a single flat list (no
+ * `CommandGroup`s) so cmdk ranks every option against each other and surfaces
+ * the closest match first. cmdk only sorts items within their own group, so
+ * keeping the category groups during search could push a closer match below
+ * weaker matches that happen to share a group with a strong one. When browsing
+ * (empty query) we keep the category headings for context.
+ */
+const CategoryOptions = ({
+  availableCategories,
+  selectedName,
+  onSelect,
+}: {
+  availableCategories: CategoryOption[];
+  selectedName: string;
+  onSelect: (option: CategoryOption) => void;
+}) => {
+  const isSearching = useCommandState(
+    (state) => state.search.trim().length > 0
+  );
+
+  const renderItem = (option: CategoryOption) => (
+    <CommandItem
+      key={option.name}
+      value={option.name}
+      onSelect={() => onSelect(option)}
+    >
+      <CheckIcon
+        className={cn(
+          "mr-2 size-4",
+          selectedName === option.name ? "opacity-100" : "opacity-0"
+        )}
+      />
+      {option.name}
+    </CommandItem>
+  );
+
+  if (isSearching) {
+    return <>{availableCategories.map(renderItem)}</>;
+  }
+
+  const grouped = availableCategories.reduce<Record<string, CategoryOption[]>>(
+    (acc, option) => {
+      const group = option.categoryName || "Other";
+      (acc[group] ??= []).push(option);
+      return acc;
+    },
+    {}
+  );
+
+  return (
+    <>
+      {Object.entries(grouped).map(([groupName, options]) => (
+        <CommandGroup key={groupName} heading={groupName}>
+          {options.map(renderItem)}
+        </CommandGroup>
+      ))}
+    </>
+  );
+};
+
 export const CategoryAutocomplete = ({
   value,
   onChange,
@@ -45,17 +109,6 @@ export const CategoryAutocomplete = ({
       return () => clearTimeout(timer);
     }
   }, [autoFocus]);
-
-  // Group options by categoryName
-  const grouped = availableCategories.reduce<Record<string, CategoryOption[]>>(
-    (acc, option) => {
-      const group = option.categoryName || "Other";
-      if (!acc[group]) acc[group] = [];
-      acc[group].push(option);
-      return acc;
-    },
-    {}
-  );
 
   return (
     <div className="space-y-1.5">
@@ -104,30 +157,14 @@ export const CategoryAutocomplete = ({
               ) : (
                 <>
                   <CommandEmpty>No activity found.</CommandEmpty>
-                  {Object.entries(grouped).map(([groupName, options]) => (
-                    <CommandGroup key={groupName} heading={groupName}>
-                      {options.map((option) => (
-                        <CommandItem
-                          key={option.name}
-                          value={option.name}
-                          onSelect={() => {
-                            onChange(option);
-                            setOpen(false);
-                          }}
-                        >
-                          <CheckIcon
-                            className={cn(
-                              "mr-2 size-4",
-                              value.name === option.name
-                                ? "opacity-100"
-                                : "opacity-0"
-                            )}
-                          />
-                          {option.name}
-                        </CommandItem>
-                      ))}
-                    </CommandGroup>
-                  ))}
+                  <CategoryOptions
+                    availableCategories={availableCategories}
+                    selectedName={value.name}
+                    onSelect={(option) => {
+                      onChange(option);
+                      setOpen(false);
+                    }}
+                  />
                 </>
               )}
             </CommandList>

--- a/client/src/pages/Welcome.stories.tsx
+++ b/client/src/pages/Welcome.stories.tsx
@@ -372,6 +372,17 @@ export const FuzzySearch: Story = {
       await screen.findByPlaceholderText(/search activities/i);
 
     await step(
+      "Browsing (empty query) keeps the category headings for context",
+      () => {
+        // The activities are grouped under their category headings while the
+        // user is just browsing the full list.
+        expect(
+          document.querySelectorAll("[cmdk-group-heading]").length
+        ).toBeGreaterThan(0);
+      }
+    );
+
+    await step(
       "Substitution typo surfaces the right activity (guards the edit-distance path)",
       async () => {
         // "Runninh" substitutes the trailing 'g' with 'h'. This is NOT an
@@ -406,6 +417,36 @@ export const FuzzySearch: Story = {
         screen.queryByRole("option", { name: /running/i })
       ).not.toBeInTheDocument();
     });
+
+    await step(
+      "Searching flattens groups so the closest match ranks first globally",
+      async () => {
+        await userEvent.clear(searchInput);
+        await userEvent.type(searchInput, "ding");
+        await waitFor(() => {
+          expect(
+            screen.getByRole("option", { name: /reading/i })
+          ).toBeInTheDocument();
+        });
+
+        // "ding" is a contiguous substring of "Reading" (Learning category) but
+        // only a typo match for "Running"/"Swimming"/"Cycling" (Sports). The
+        // exact substring match must rank first, ahead of the typo matches —
+        // even though they live in a different, earlier category.
+        const options = screen.getAllByRole("option");
+        expect(options[0]).toHaveTextContent(/reading/i);
+        expect(
+          screen.getByRole("option", { name: /running/i })
+        ).toBeInTheDocument();
+
+        // While searching, options render as one flat list (no category
+        // headings) so cmdk sorts every option against each other globally
+        // instead of only within its own group.
+        expect(
+          document.querySelectorAll("[cmdk-group-heading]").length
+        ).toBe(0);
+      }
+    );
 
     await step("Select a typo-matched option", async () => {
       await userEvent.clear(searchInput);

--- a/client/src/utils/fuzzyFilter.ts
+++ b/client/src/utils/fuzzyFilter.ts
@@ -12,8 +12,10 @@ import { defaultFilter } from "cmdk";
  * Strategy:
  *   1. Defer to `defaultFilter`. If it matches (> 0), return its score so the
  *      built-in ranking is preserved.
- *   2. Otherwise fall back to a bounded edit-distance check and return a flat
- *      score for plausible typo matches.
+ *   2. Otherwise fall back to a bounded edit-distance check and return a graded
+ *      score (kept below cmdk's contiguous-match scores) for typo matches, so a
+ *      typo never outranks a real substring match and the closest typo ranks
+ *      first.
  *
  * Edit-distance thresholds scale with query length so short queries stay
  * precise (a 1-edit window on a 2-char query would match almost anything):
@@ -36,15 +38,27 @@ export function fuzzyFilter(
   return typoToleranceScore(value, search);
 }
 
-/** Score (0.5) for queries within the allowed edit distance, else 0. */
+/**
+ * Graded score for queries within the allowed edit distance, else 0.
+ *
+ * The score sits in a low band (below ~0.15). cmdk's `defaultFilter` scores
+ * contiguous substring matches at roughly 0.17 or higher, so keeping typo
+ * matches beneath that band guarantees a real substring match always ranks
+ * above a typo. Within the band the score scales with match quality (fewer
+ * edits → higher score), so the closest typo appears first.
+ */
 function typoToleranceScore(value: string, search: string): number {
   const srch = search.toLowerCase();
   const maxErrors = srch.length < 3 ? 0 : srch.length < 6 ? 1 : 2;
   if (maxErrors === 0) return 0;
 
-  return minEditDistanceInSubstring(value.toLowerCase(), srch) <= maxErrors
-    ? 0.5
-    : 0;
+  const distance = minEditDistanceInSubstring(value.toLowerCase(), srch);
+  if (distance > maxErrors) return 0;
+
+  // distance is always >= 1 here: a distance of 0 is an exact substring, which
+  // `defaultFilter` would already have scored above 0 before we got here.
+  const TYPO_BAND_CEILING = 0.15;
+  return TYPO_BAND_CEILING * (1 - distance / (srch.length + 1));
 }
 
 /**


### PR DESCRIPTION
Follow-up to #1166 (typo-tolerant fuzzy matching), which is already merged.

While testing the merged picker, the closest match wasn't always shown highest: an exact substring match in one category could appear *below* weaker/typo matches from another category. This PR fixes the ranking.

## Root cause

cmdk only sorts items **within** their own `CommandGroup` — groups float to the top by their best item's score, but a closer match living in a later group stays buried under weaker matches that happen to share a group with a strong one. Separately, the typo fallback returned a flat `0.5`, which outranked cmdk's contiguous-substring scores (~0.17), so a typo could sit above an exact substring match.

## Changes

- **`CategoryAutocomplete`** — while a query is active, render options as a single **flat list** (no `CommandGroup`) so cmdk sorts every option globally, best match first. Category headings are kept when browsing the full (empty-query) list.
- **`fuzzyFilter`** — replace the flat `0.5` typo score with a **graded score in a low band (<0.15)** that stays below cmdk's contiguous-substring scores. A typo can no longer outrank an exact substring match, and the closest typo (fewer edits) ranks ahead of looser ones.

## Tests

Extends the `FuzzySearch` Storybook story to assert:
- a contiguous substring match (`"ding"` → Reading) ranks above typo matches from another category,
- group headings are present when browsing and absent when searching (flat global sort).

All 71 client Storybook tests pass; lint + tsc clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>